### PR TITLE
Fikser bug der correlationId fører til omp-ao med 2 eller flere barn burde lage flere jp-er, lager kun 1.

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogprosessering/meldinger/omsorgspengeraleneomsorg/domene/OMPAleneomsorgSoknadPreprosessert.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogprosessering/meldinger/omsorgspengeraleneomsorg/domene/OMPAleneomsorgSoknadPreprosessert.kt
@@ -50,6 +50,7 @@ data class OMPAleneomsorgSoknadPreprosessert(
 
     override fun tilJournaførigsRequest() = JournalføringsRequest(
         ytelse = ytelse(),
+        correlationId = søknadId,
         norskIdent = søkerFødselsnummer(),
         sokerNavn = søkerNavn(),
         mottatt = mottattDato(),

--- a/src/main/kotlin/no/nav/k9brukerdialogprosessering/utils/RestTemplateUtils.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogprosessering/utils/RestTemplateUtils.kt
@@ -40,9 +40,7 @@ object RestTemplateUtils {
         ClientHttpRequestInterceptor { request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution ->
             val correlationId = MDC.get(CORRELATION_ID_KEY) ?: UUID.randomUUID().toString()
             request.headers[NAV_CALL_ID] = correlationId
-            if (request.headers[X_CORRELATION_ID] == null) {
-                request.headers[X_CORRELATION_ID] = correlationId
-            }
+            request.headers.computeIfAbsent(CORRELATION_ID_KEY) { listOf(correlationId) }
             execution.execute(request, body)
         }
 

--- a/src/main/kotlin/no/nav/k9brukerdialogprosessering/utils/RestTemplateUtils.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogprosessering/utils/RestTemplateUtils.kt
@@ -40,7 +40,7 @@ object RestTemplateUtils {
         ClientHttpRequestInterceptor { request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution ->
             val correlationId = MDC.get(CORRELATION_ID_KEY) ?: UUID.randomUUID().toString()
             request.headers[NAV_CALL_ID] = correlationId
-            request.headers.computeIfAbsent(CORRELATION_ID_KEY) { listOf(correlationId) }
+            request.headers.computeIfAbsent(X_CORRELATION_ID) { listOf(correlationId) }
             execution.execute(request, body)
         }
 

--- a/src/main/kotlin/no/nav/k9brukerdialogprosessering/utils/RestTemplateUtils.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogprosessering/utils/RestTemplateUtils.kt
@@ -40,7 +40,9 @@ object RestTemplateUtils {
         ClientHttpRequestInterceptor { request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution ->
             val correlationId = MDC.get(CORRELATION_ID_KEY) ?: UUID.randomUUID().toString()
             request.headers[NAV_CALL_ID] = correlationId
-            request.headers[X_CORRELATION_ID] = correlationId
+            if (request.headers[X_CORRELATION_ID] == null) {
+                request.headers[X_CORRELATION_ID] = correlationId
+            }
             execution.execute(request, body)
         }
 

--- a/src/test/kotlin/no/nav/k9brukerdialogprosessering/journalforing/K9JoarkServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogprosessering/journalforing/K9JoarkServiceTest.kt
@@ -42,6 +42,7 @@ class K9JoarkServiceTest {
             norskIdent = "12345678910",
             sokerNavn = Navn("John", "Doe", "Hansen"),
             mottatt = ZonedDateTime.now(),
+            correlationId = "123456789",
             dokumentId = listOf(listOf("123", "456"))
         )
         val journalføringsResponse = JournalføringsResponse("9876543210")
@@ -50,6 +51,7 @@ class K9JoarkServiceTest {
             urlPathMatching = "/v1/pleiepenge/journalforing",
             requestBodyJson = objectMapper.writeValueAsString(journalføringsRequest),
             responseStatus = HttpStatus.OK,
+            correlationId = "123456789",
             responseBodyJson = objectMapper.writeValueAsString(journalføringsResponse)
         )
 

--- a/src/test/kotlin/no/nav/k9brukerdialogprosessering/utils/WireMockServerUtils.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogprosessering/utils/WireMockServerUtils.kt
@@ -2,6 +2,7 @@ package no.nav.k9brukerdialogprosessering.utils
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
+import no.nav.k9brukerdialogprosessering.common.Constants.X_CORRELATION_ID
 import org.springframework.http.HttpStatus
 
 object WireMockServerUtils {
@@ -9,13 +10,20 @@ object WireMockServerUtils {
         urlPathMatching: String,
         requestBodyJson: String,
         responseStatus: HttpStatus,
+        correlationId: String? = null,
         responseBodyJson: String,
     ) {
+        val response = WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(responseStatus.value()).withBody(responseBodyJson)
+
+        if (correlationId != null) {
+            response.withHeader(X_CORRELATION_ID, correlationId)
+        }
         stubFor(
             WireMock.post(WireMock.urlPathMatching(".*$urlPathMatching"))
                 .withRequestBody(WireMock.equalToJson(requestBodyJson)).willReturn(
-                    WireMock.aResponse().withHeader("Content-Type", "application/json")
-                        .withStatus(responseStatus.value()).withBody(responseBodyJson)
+                    response
                 )
         )
     }


### PR DESCRIPTION
Når det blir sendt inn en søknad med to barn så splittes det og de får hver sin søknadsId, men correlationId er det samme. Det fører til at når man journalfører omp-ao og gjenbruker correlationId så oppdaterer man samme journalpost.

For å løse det legger jeg på correlationId i payload og overstyrer headeren med verdi fra søknadsId.