### PR TITLE
Ikke vis pleietrengende-punkt om man ikke har dataen til det

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogprosessering/pdf/PDFGenerator.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogprosessering/pdf/PDFGenerator.kt
@@ -35,7 +35,7 @@ class PDFGenerator {
     private companion object {
         private val ROOT = "handlebars"
         private val REGULAR_FONT =
-            ClassPathResource("${ROOT}/fonts/SourceSansPro-Regular.ttf").inputStream.readAllBytes()
+                ClassPathResource("${ROOT}/fonts/SourceSansPro-Regular.ttf").inputStream.readAllBytes()
         private val BOLD_FONT = ClassPathResource("${ROOT}/fonts/SourceSansPro-Bold.ttf").inputStream.readAllBytes()
         private val ITALIC_FONT = ClassPathResource("${ROOT}/fonts/SourceSansPro-Italic.ttf").inputStream.readAllBytes()
         private val bilder: Map<String, String> = emptyMap()
@@ -67,7 +67,7 @@ class PDFGenerator {
 
         private fun Handlebars.isNotNullHelper() {
             registerHelper("isNotNull", Helper<Any> { context, options ->
-               return@Helper if (context != null) {
+                return@Helper if (context != null) {
                     options.fn()
                 } else {
                     options.inverse()
@@ -85,9 +85,9 @@ class PDFGenerator {
             registerHelper("fritekst", Helper<String> { context, _ ->
                 if (context == null) "" else {
                     val text = Handlebars.Utils.escapeExpression(context)
-                        .toString()
-                        .replace(Regex("\\u0002"), " ")
-                        .replace(Regex("\\r\\n|[\\n\\r]"), "<br/>")
+                            .toString()
+                            .replace(Regex("\\u0002"), " ")
+                            .replace(Regex("\\r\\n|[\\n\\r]"), "<br/>")
                     Handlebars.SafeString(text)
                 }
             })
@@ -158,7 +158,7 @@ class PDFGenerator {
 
         private fun Handlebars.fraværSomFormatHelper() {
             registerHelper("fraværSomFormat", Helper<List<String>> { context, _ ->
-                when(context.size) {
+                when (context.size) {
                     1 -> "Fravær som"
                     2 -> "Fravær både som"
                     else -> ""
@@ -168,7 +168,7 @@ class PDFGenerator {
 
         private fun Handlebars.aktivitetFraværHelper() {
             registerHelper("aktivitetFravær", Helper<String> { context, _ ->
-                when(AktivitetFravær.valueOf(context)) {
+                when (AktivitetFravær.valueOf(context)) {
                     AktivitetFravær.FRILANSER -> "frilanser"
                     AktivitetFravær.SELVSTENDIG_VIRKSOMHET -> "selvstendig næringsdrivende"
                 }
@@ -176,54 +176,56 @@ class PDFGenerator {
         }
     }
 
-fun genererPDF(pdfData: PdfData): ByteArray = template(pdfData)
-    .apply(
-        Context
-            .newBuilder(pdfData.pdfData())
-            .resolver(MapValueResolver.INSTANCE)
-            .build()
-    ).let { html ->
+    fun genererPDF(pdfData: PdfData): ByteArray = genererHTML(pdfData).let { html ->
         val outputStream = ByteArrayOutputStream()
         PdfRendererBuilder()
-            .useFastMode()
-            .usePdfUaAccessbility(true)
-            .withHtmlContent(html, "")
-            .medFonter()
-            .toStream(outputStream)
-            .buildPdfRenderer()
-            .createPDF()
+                .useFastMode()
+                .usePdfUaAccessbility(true)
+                .withHtmlContent(html, "")
+                .medFonter()
+                .toStream(outputStream)
+                .buildPdfRenderer()
+                .createPDF()
 
         outputStream.use {
             it.toByteArray()
         }
     }
 
-private fun template(pdfData: PdfData): Template = handlebars.compile(pdfData.resolveTemplate())
+    fun genererHTML(pdfData: PdfData): String = template(pdfData)
+            .apply(
+                    Context
+                            .newBuilder(pdfData.pdfData())
+                            .resolver(MapValueResolver.INSTANCE)
+                            .build()
+            )
 
-private fun PdfRendererBuilder.medFonter(): PdfRendererBuilder {
-    val sourceSansPro = "Source Sans Pro"
-    return useFont(
-        { ByteArrayInputStream(REGULAR_FONT) },
-        sourceSansPro,
-        400,
-        BaseRendererBuilder.FontStyle.NORMAL,
-        false
-    )
-        .useFont(
-            { ByteArrayInputStream(BOLD_FONT) },
-            sourceSansPro,
-            700,
-            BaseRendererBuilder.FontStyle.NORMAL,
-            false
+    private fun template(pdfData: PdfData): Template = handlebars.compile(pdfData.resolveTemplate())
+
+    private fun PdfRendererBuilder.medFonter(): PdfRendererBuilder {
+        val sourceSansPro = "Source Sans Pro"
+        return useFont(
+                { ByteArrayInputStream(REGULAR_FONT) },
+                sourceSansPro,
+                400,
+                BaseRendererBuilder.FontStyle.NORMAL,
+                false
         )
-        .useFont(
-            { ByteArrayInputStream(ITALIC_FONT) },
-            sourceSansPro,
-            400,
-            BaseRendererBuilder.FontStyle.ITALIC,
-            false
-        )
-}
+                .useFont(
+                        { ByteArrayInputStream(BOLD_FONT) },
+                        sourceSansPro,
+                        700,
+                        BaseRendererBuilder.FontStyle.NORMAL,
+                        false
+                )
+                .useFont(
+                        { ByteArrayInputStream(ITALIC_FONT) },
+                        sourceSansPro,
+                        400,
+                        BaseRendererBuilder.FontStyle.ITALIC,
+                        false
+                )
+    }
 }
 
 abstract class PdfData {

--- a/src/main/resources/handlebars/ettersendelse.hbs
+++ b/src/main/resources/handlebars/ettersendelse.hbs
@@ -28,7 +28,9 @@
 
     <div class="innholdscontainer">
         {{> partial/felles/personPartial id="søker" title="Søker" navn=søker.navn fødselsnummer=søker.fødselsnummer }}
+        {{#if pleietrengende}}
         {{> partial/felles/personPartial id="barn" title="Pleietrengende" navn=pleietrengende.navn fødselsnummer=pleietrengende.norskIdentitetsnummer fødselsdato=pleietrengende.fødselsdato }}
+        {{/if}}
     </div>
 
     <!-- Ettersending -->

--- a/src/test/kotlin/no/nav/k9brukerdialogprosessering/meldinger/ettersendelse/EttersendelsePdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogprosessering/meldinger/ettersendelse/EttersendelsePdfGeneratorTest.kt
@@ -1,9 +1,13 @@
 package no.nav.k9brukerdialogprosessering.meldinger.ettersendelse
 
+import junit.framework.TestCase.assertTrue
 import no.nav.k9brukerdialogprosessering.meldinger.ettersendelse.domene.Søknadstype
 import no.nav.k9brukerdialogprosessering.meldinger.ettersendelse.utils.EttersendingUtils
 import no.nav.k9brukerdialogprosessering.pdf.PDFGenerator
+import no.nav.k9brukerdialogprosessering.pdf.PdfData
 import no.nav.k9brukerdialogprosessering.utils.PathUtils.pdfPath
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.File
@@ -23,6 +27,21 @@ class EttersendelsePdfGeneratorTest {
         genererOppsummeringsPdfer(søknadstype, true)
     }
 
+    @Test
+    fun `informasjon om barn inkluderes i pdf om det er pleietrengende`() {
+        val html = generator.genererHTML(EttersendingUtils.defaultEttersendelse().copy().pdfData())
+        Assertions.assertTrue(html.contains("Pleietrengende"))
+    }
+
+    @Test
+    fun `informasjon om barn inkluderes ikke i pdf om det ikke er pleietrengende`() {
+        val html = generator.genererHTML(EttersendingUtils.defaultEttersendelse().copy(
+                pleietrengende = null
+        ).pdfData())
+        Assertions.assertFalse(html.contains("Pleietrengende"))
+    }
+
+
     private companion object {
         const val PDF_PREFIX = "ettersendelse"
         private val generator = PDFGenerator()
@@ -31,10 +50,10 @@ class EttersendelsePdfGeneratorTest {
     private fun genererOppsummeringsPdfer(søknadstype: Søknadstype, writeBytes: Boolean) {
         val id = søknadstype.name.lowercase()
         val pdf = generator.genererPDF(
-            EttersendingUtils.defaultEttersendelse(id, ZonedDateTime.now()).copy(
-                søknadstype = søknadstype,
-                beskrivelse = null
-            ).pdfData()
+                EttersendingUtils.defaultEttersendelse(id, ZonedDateTime.now()).copy(
+                        søknadstype = søknadstype,
+                        beskrivelse = null
+                ).pdfData()
         )
 
         if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)


### PR DESCRIPTION
Når man ettersender informasjon, og ikke har informasjon om pleietrengende, så viser man "Navn ikke oppgitt" i den genererte PDFen. Det er ikke noe vits.

Denne PRen fjerner den delen av outputen om man ikke har info om pleietrengende, og legger til noen tester for å verifisere det.