### PR TITLE
Legg til informasjon om barnet er sammen med søker i PDF for PSB-søknad

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/PSBSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/PSBSøknadPdfData.kt
@@ -342,6 +342,7 @@ class PSBSøknadPdfData(private val søknad: PSBMottattSøknad) : PdfData() {
                 "fraOgMed" to dateFormatter.format(it.fraOgMed),
                 "tilOgMed" to dateFormatter.format(it.tilOgMed),
                 "erUtenforEØS" to it.erUtenforEøs,
+                "erSammenMedBarnet" to it.erSammenMedBarnet,
                 "erBarnetInnlagt" to it.erBarnetInnlagt,
                 "perioderBarnetErInnlagt" to it.perioderBarnetErInnlagt.somMapPerioder(),
                 "årsak" to it.årsak?.beskrivelse

--- a/src/main/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/domene/felles/Felles.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/domene/felles/Felles.kt
@@ -92,12 +92,13 @@ data class Utenlandsopphold(
     val landkode: String,
     val landnavn: String,
     val erUtenforEøs: Boolean?,
+    val erSammenMedBarnet: Boolean?,
     val erBarnetInnlagt: Boolean?,
     val perioderBarnetErInnlagt: List<Periode> = listOf(),
     val årsak: Årsak?
 ) {
     override fun toString(): String {
-        return "Utenlandsopphold(fraOgMed=$fraOgMed, tilOgMed=$tilOgMed, landkode='$landkode', landnavn='$landnavn', erUtenforEøs=$erUtenforEøs, erBarnetInnlagt=$erBarnetInnlagt, årsak=$årsak)"
+        return "Utenlandsopphold(fraOgMed=$fraOgMed, tilOgMed=$tilOgMed, landkode='$landkode', landnavn='$landnavn', erUtenforEøs=$erUtenforEøs, erSammenMedBarnet=$erSammenMedBarnet, erBarnetInnlagt=$erBarnetInnlagt, årsak=$årsak)"
     }
 }
 

--- a/src/main/resources/handlebars/pleiepenger-sykt-barn-soknad.hbs
+++ b/src/main/resources/handlebars/pleiepenger-sykt-barn-soknad.hbs
@@ -485,7 +485,9 @@
                         {{#if opphold.erUtenforEØS}}
                             {{#if opphold.erBarnetInnlagt}}
                                 <p><b>Er barnet innlagt?</b> {{ jaNeiSvar opphold.erBarnetInnlagt }}</p>
-                                <p><b>Er barnet sammen med deg?</b> {{ jaNeiSvar opphold.erSammenMedBarnet }}</p>
+                                {{#if isNotNull opphold.erSammenMedBarnet }}
+                                    <p><b>Er barnet sammen med deg?</b> {{ jaNeiSvar opphold.erSammenMedBarnet }}</p>
+                                {{/if}}
                                 <p><b>Perioder:</b>
                                     {{# each opphold.perioderBarnetErInnlagt as |periode| }}
                                         {{#if @last}}

--- a/src/main/resources/handlebars/pleiepenger-sykt-barn-soknad.hbs
+++ b/src/main/resources/handlebars/pleiepenger-sykt-barn-soknad.hbs
@@ -485,6 +485,7 @@
                         {{#if opphold.erUtenforEØS}}
                             {{#if opphold.erBarnetInnlagt}}
                                 <p><b>Er barnet innlagt?</b> {{ jaNeiSvar opphold.erBarnetInnlagt }}</p>
+                                <p><b>Er barnet sammen med deg?</b> {{ jaNeiSvar opphold.erSammenMedBarnet }}</p>
                                 <p><b>Perioder:</b>
                                     {{# each opphold.perioderBarnetErInnlagt as |periode| }}
                                         {{#if @last}}

--- a/src/test/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/PSBSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/PSBSøknadPdfGeneratorTest.kt
@@ -118,6 +118,7 @@ class PSBSøknadPdfGeneratorTest {
                             landkode = "BAH",
                             erUtenforEøs = true,
                             erBarnetInnlagt = true,
+                            erSammenMedBarnet = true,
                             perioderBarnetErInnlagt = listOf(
                                 Periode(
                                     fraOgMed = LocalDate.parse("2020-01-01"),
@@ -137,6 +138,7 @@ class PSBSøknadPdfGeneratorTest {
                             landkode = "BHS",
                             erUtenforEøs = false,
                             erBarnetInnlagt = true,
+                            erSammenMedBarnet = true,
                             perioderBarnetErInnlagt = listOf(
                                 Periode(
                                     fraOgMed = LocalDate.parse("2020-01-01"),

--- a/src/test/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/PleiepengerSyktBarnSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/PleiepengerSyktBarnSøknadKonsumentTest.kt
@@ -294,6 +294,7 @@ class PleiepengerSyktBarnSøknadKonsumentTest {
                 {
                   "erBarnetInnlagt": true,
                   "erUtenforEøs": true,
+                  "erSammenMedBarnet": true,
                   "fraOgMed": "2020-01-01",
                   "landkode": "BAH",
                   "landnavn": "Bahamas",
@@ -313,6 +314,7 @@ class PleiepengerSyktBarnSøknadKonsumentTest {
                 {
                   "erBarnetInnlagt": true,
                   "erUtenforEøs": false,
+                  "erSammenMedBarnet": true,
                   "fraOgMed": "2020-01-01",
                   "landkode": "BHS",
                   "landnavn": "Svergie",

--- a/src/test/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/utils/PSBSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogprosessering/meldinger/pleiepengersyktbarn/utils/PSBSøknadUtils.kt
@@ -88,6 +88,7 @@ internal object PSBSøknadUtils {
                     landkode = "BAH",
                     erUtenforEøs = true,
                     erBarnetInnlagt = true,
+                    erSammenMedBarnet = true,
                     perioderBarnetErInnlagt = listOf(
                         Periode(
                             fraOgMed = LocalDate.parse("2020-01-01"),
@@ -107,6 +108,7 @@ internal object PSBSøknadUtils {
                     landkode = "BHS",
                     erUtenforEøs = false,
                     erBarnetInnlagt = true,
+                    erSammenMedBarnet = true,
                     perioderBarnetErInnlagt = listOf(
                         Periode(
                             fraOgMed = LocalDate.parse("2020-01-01"),


### PR DESCRIPTION
Denne PRen legger til et avsnitt per utenlandsopphold som viser om barnet er sammen med søker på det utenlandsoppholdet.

Se også: https://github.com/navikt/k9-brukerdialog-api/pull/381