### PR TITLE
Legger til mottak og prosessering av søknad om ungdomsytelse.

### DIFF
--- a/.github/workflows/deploy-ungdomsytelse-soknad-topics.yml
+++ b/.github/workflows/deploy-ungdomsytelse-soknad-topics.yml
@@ -1,4 +1,4 @@
-name: Deploy ettersendelse topics
+name: Deploy ungdomsytelsesøknad topics
 
 env:
   TOPICS_PATH: 'nais/topics/ungdomsytelse-soknad-topics.yml'

--- a/.github/workflows/deploy-ungdomsytelse-soknad-topics.yml
+++ b/.github/workflows/deploy-ungdomsytelse-soknad-topics.yml
@@ -1,0 +1,21 @@
+name: Deploy ettersendelse topics
+
+env:
+  TOPICS_PATH: 'nais/topics/ungdomsytelse-soknad-topics.yml'
+
+on:
+  push:
+    paths:
+      - '.github/workflows/deploy-ungdomsytelse-soknad-topics.yml'
+      - '.github/workflows/reusable-topic-workflow.yml'
+      - 'nais/topics/ungdomsytelse-soknad-topics.yml'
+
+jobs:
+  deploy-ungdomsytelse-soknad-topics:
+    permissions:
+      id-token: write
+    uses: ./.github/workflows/reusable-topic-workflow.yml
+    with:
+      job-name: ungdomsytelse-soknad-topics
+      topics-path: 'nais/topics/ungdomsytelse-soknad-topics.yml'
+    secrets: inherit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ repositories {
 
 val tokenSupportVersion = "5.0.3"
 val jsonassertVersion = "1.5.3"
-val k9FormatVersion = "9.5.2"
+val k9FormatVersion = "9.6.0"
 val springMockkVersion = "4.0.2"
 val confluentVersion = "7.3.0"
 val logstashLogbackEncoderVersion = "8.0"

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -44,7 +44,9 @@
     "K9_SELVBETJENING_OPPSLAG_TOKEN_X_AUDIENCE": "dev-gcp:dusseldorf:k9-selvbetjening-oppslag",
 
     "KAFKA_CONSUMER_GROUP_ID": "k9-brukerdialog-prosessering",
-    "SWAGGER_ENABLED": "true"
+    "SWAGGER_ENABLED": "true",
+
+    "ENABLE_UNDOMSYTELSE": "true"
   },
   "slack-channel": "sif-alerts-dev",
   "slack-notify-type": "<!here> | k9-brukerdialog-prosessering | "

--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -33,6 +33,7 @@ spec:
         - application: endringsmelding-pleiepenger
         - application: dine-pleiepenger
         - application: opplaringspenger-soknad
+        - application: ungdomsytelse-soknad
       {{#each inboundRules}}
         - application: {{app}}
           namespace: {{namespace}}

--- a/nais/topics/ungdomsytelse-soknad-topics.yml
+++ b/nais/topics/ungdomsytelse-soknad-topics.yml
@@ -1,0 +1,66 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: ungdomsytelse-soknad-mottatt
+  namespace: dusseldorf
+  labels:
+    team: dusseldorf
+spec:
+  pool: {{kafka-pool}}
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 2
+    partitions: 1
+    replication: 3
+    retentionBytes: -1  # -1 ubegrenset
+    retentionHours: 730 # 30 dager
+  acl:
+    - team: dusseldorf
+      application: k9-brukerdialog-prosessering
+      access: readwrite
+
+---
+
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: ungdomsytelse-soknad-preprosessert
+  namespace: dusseldorf
+  labels:
+    team: dusseldorf
+spec:
+  pool: {{kafka-pool}}
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 2
+    partitions: 1
+    replication: 3  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 730 # 30 dager
+  acl:
+    - team: dusseldorf
+      application: k9-brukerdialog-prosessering
+      access: readwrite
+
+---
+
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: ungdomsytelse-soknad-cleanup
+  namespace: dusseldorf
+  labels:
+    team: dusseldorf
+spec:
+  pool: {{kafka-pool}}
+  config:
+    cleanupPolicy: delete  # delete, compact
+    minimumInSyncReplicas: 2
+    partitions: 1
+    replication: 3  # see min/max requirements
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: 730 # 30 dager
+  acl:
+    - team: dusseldorf
+      application: k9-brukerdialog-prosessering
+      access: readwrite

--- a/src/main/kotlin/no/nav/brukerdialog/common/Ytelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/common/Ytelse.kt
@@ -27,6 +27,9 @@ import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.kafka.PILSTopolog
 import no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.kafka.PSBTopologyConfiguration.Companion.PSB_CLEANUP_TOPIC
 import no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.kafka.PSBTopologyConfiguration.Companion.PSB_MOTTATT_TOPIC
 import no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.kafka.PSBTopologyConfiguration.Companion.PSB_PREPROSESSERT_TOPIC
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_CLEANUP_TOPIC
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC
 
 enum class Ytelse(val tittel: String) {
     OMSORGSPENGER_UTVIDET_RETT("Søknad om ekstra omsorgsdager for barn som har kronisk/langvarig sykdom eller funksjonshemning"),
@@ -37,7 +40,9 @@ enum class Ytelse(val tittel: String) {
     OMSORGSPENGER_UTBETALING_SNF("Søknad om utbetaling av omsorgspenger for selvstendig næringsdrivende og frilansere"),
     PLEIEPENGER_LIVETS_SLUTTFASE("Søknad om pleiepenger i livets sluttfase"),
     PLEIEPENGER_SYKT_BARN("Søknad om pleiepenger for sykt barn"),
-    PLEIEPENGER_SYKT_BARN_ENDRINGSMELDING("Endringsmelding for pleiepenger sykt barn");
+    PLEIEPENGER_SYKT_BARN_ENDRINGSMELDING("Endringsmelding for pleiepenger sykt barn"),
+    UNGDOMSYTELSE("Søknad om ungdomsytelse")
+    ;
 
     companion object {
         fun fraTopic(topic: String): Ytelse = when (topic) {
@@ -50,6 +55,7 @@ enum class Ytelse(val tittel: String) {
             OMP_UTB_SNF_MOTTATT_TOPIC, OMP_UTB_SNF_PREPROSESSERT_TOPIC, OMP_UTB_SNF_CLEANUP_TOPIC -> OMSORGSPENGER_UTBETALING_SNF
             OMP_MA_MOTTATT_TOPIC, OMP_MA_PREPROSESSERT_TOPIC, OMP_MA_CLEANUP_TOPIC -> OMSORGSPENGER_MIDLERTIDIG_ALENE
             OMP_AO_MOTTATT_TOPIC, OMP_AO_PREPROSESSERT_TOPIC, OMP_AO_CLEANUP_TOPIC -> OMSORGSDAGER_ALENEOMSORG
+            UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC, UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC, UNGDOMSYTELSE_SØKNAD_CLEANUP_TOPIC -> UNGDOMSYTELSE
             else -> {
                 throw IllegalArgumentException("Kan ikke finne ytelse for topic: $topic")
             }

--- a/src/main/kotlin/no/nav/brukerdialog/integrasjon/k9joark/K9JoarkService.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/integrasjon/k9joark/K9JoarkService.kt
@@ -108,6 +108,11 @@ class K9JoarkService(
             .fromPath("/v1/omsorgsdager/aleneomsorg/journalforing")
             .build()
             .toUri()
+
+        Ytelse.UNGDOMSYTELSE -> UriComponentsBuilder
+            .fromPath("/v1/ungdomsytelse/soknad/journalforing")
+            .build()
+            .toUri()
     }
 }
 

--- a/src/main/kotlin/no/nav/brukerdialog/kafka/KafkaProducerService.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/kafka/KafkaProducerService.kt
@@ -13,6 +13,7 @@ import no.nav.brukerdialog.kafka.Topics.OMSORGSPENGER_UTBETALING_SNF_TOPIC
 import no.nav.brukerdialog.kafka.Topics.OMSORGSPENGER_UTVIDET_RETT_TOPIC
 import no.nav.brukerdialog.kafka.Topics.PLEIEPENGER_LIVETS_SLUTTFASE_TOPIC
 import no.nav.brukerdialog.kafka.Topics.PLEIEPENGER_SYKT_BARN_TOPIC
+import no.nav.brukerdialog.kafka.Topics.UNGDOMSYTELSE_SOKNAD_TOPIC
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.json.JSONObject
@@ -77,6 +78,7 @@ class KafkaProducerService(
             aivenKafkaTemplate.partitionsFor(PLEIEPENGER_LIVETS_SLUTTFASE_TOPIC)
             aivenKafkaTemplate.partitionsFor(MOTTATT_ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN_TOPIC)
             aivenKafkaTemplate.partitionsFor(PLEIEPENGER_SYKT_BARN_TOPIC)
+            aivenKafkaTemplate.partitionsFor(UNGDOMSYTELSE_SOKNAD_TOPIC)
 
             Mono.just(Health.up().withDetail(NAME, "Tilkobling til Kafka OK!").build())
         } catch (cause: Throwable) {

--- a/src/main/kotlin/no/nav/brukerdialog/kafka/Topics.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/kafka/Topics.kt
@@ -24,6 +24,7 @@ import no.nav.brukerdialog.kafka.Topics.OMSORGSPENGER_UTBETALING_SNF_TOPIC
 import no.nav.brukerdialog.kafka.Topics.OMSORGSPENGER_UTVIDET_RETT_TOPIC
 import no.nav.brukerdialog.kafka.Topics.PLEIEPENGER_LIVETS_SLUTTFASE_TOPIC
 import no.nav.brukerdialog.kafka.Topics.PLEIEPENGER_SYKT_BARN_TOPIC
+import no.nav.brukerdialog.kafka.Topics.UNGDOMSYTELSE_SOKNAD_TOPIC
 import org.apache.kafka.common.serialization.Serializer
 import org.json.JSONObject
 
@@ -36,8 +37,8 @@ object Topics {
     const val OMSORGSPENGER_UTBETALING_SNF_TOPIC = "dusseldorf.omp-utbetaling-snf-soknad-mottatt"
     const val PLEIEPENGER_LIVETS_SLUTTFASE_TOPIC = "dusseldorf.pp-i-livets-sluttfase-soknad-mottatt"
     const val PLEIEPENGER_SYKT_BARN_TOPIC = "dusseldorf.pp-sykt-barn-soknad-mottatt"
-    const val MOTTATT_ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN_TOPIC =
-        "dusseldorf.privat-endringsmelding-pleiepenger-sykt-barn-mottatt"
+    const val MOTTATT_ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN_TOPIC = "dusseldorf.privat-endringsmelding-pleiepenger-sykt-barn-mottatt"
+    const val UNGDOMSYTELSE_SOKNAD_TOPIC = "dusseldorf.privat-ungdomsytelse-soknad-mottatt"
 }
 
 data class TopicEntry<V>(
@@ -56,6 +57,7 @@ internal fun hentTopicForYtelse(ytelse: Ytelse) = when (ytelse) {
     PLEIEPENGER_SYKT_BARN -> PLEIEPENGER_SYKT_BARN_TOPIC
     ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN -> MOTTATT_ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN_TOPIC
     DINE_PLEIEPENGER -> throw IllegalArgumentException("$ytelse er ikke en gyldig ytelse for denne operasjonen")
+    Ytelse.UNGDOMSYTELSE -> UNGDOMSYTELSE_SOKNAD_TOPIC
     Ytelse.OPPLARINGSPENGER -> TODO("Må opprette topic. Se nais/topics i rot av repo")
 }
 

--- a/src/main/kotlin/no/nav/brukerdialog/kafka/Topics.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/kafka/Topics.kt
@@ -38,7 +38,7 @@ object Topics {
     const val PLEIEPENGER_LIVETS_SLUTTFASE_TOPIC = "dusseldorf.pp-i-livets-sluttfase-soknad-mottatt"
     const val PLEIEPENGER_SYKT_BARN_TOPIC = "dusseldorf.pp-sykt-barn-soknad-mottatt"
     const val MOTTATT_ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN_TOPIC = "dusseldorf.privat-endringsmelding-pleiepenger-sykt-barn-mottatt"
-    const val UNGDOMSYTELSE_SOKNAD_TOPIC = "dusseldorf.privat-ungdomsytelse-soknad-mottatt"
+    const val UNGDOMSYTELSE_SOKNAD_TOPIC = "dusseldorf.ungdomsytelse-soknad-mottatt"
 }
 
 data class TopicEntry<V>(

--- a/src/main/kotlin/no/nav/brukerdialog/kafka/config/KafkaProperties.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/kafka/config/KafkaProperties.kt
@@ -95,4 +95,9 @@ enum class KafkaStreamName(val value: String) {
     OMP_AO_PREPROSESSERING("omp-ao-preprosessering"),
     OMP_AO_JOURNALFØRING("omp-ao-journalforing"),
     OMP_AO_CLEANUP("omp-ao-cleanup"),
+
+    //Ungdomsytelse
+    UNGDOMSYTELSE_SØKNAD_PREPROSESSERING("ungdomsytelse-soknad-preprosessering"),
+    UNGDOMSYTELSE_SØKNAD_JOURNALFØRING("ungdomsytelse-soknad-journalforing"),
+    UNGDOMSYTELSE_SØKNAD_CLEANUP("ungdomsytelse-soknad-cleanup"),
 }

--- a/src/main/kotlin/no/nav/brukerdialog/pdf/PDFGenerator.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/pdf/PDFGenerator.kt
@@ -241,5 +241,6 @@ abstract class PdfData {
         Ytelse.OMSORGSPENGER_UTBETALING_ARBEIDSTAKER -> "omsorgspenger-utbetaling-arbeidstaker-soknad"
         Ytelse.OMSORGSPENGER_UTBETALING_SNF -> "omsorgspenger-utbetaling-snf-soknad"
         Ytelse.ETTERSENDELSE -> "ettersendelse"
+        Ytelse.UNGDOMSYTELSE -> "ungdomsytelse-soknad"
     }
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/Ytelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/Ytelse.kt
@@ -23,7 +23,9 @@ enum class Ytelse(val dialog: String) {
     PLEIEPENGER_SYKT_BARN("pleiepengesoknad"),
     ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN("endringsmelding-pleiepenger"),
     DINE_PLEIEPENGER("dine-pleiepenger"),
-    OPPLARINGSPENGER("opplaringspenger-soknad");
+    OPPLARINGSPENGER("opplaringspenger-soknad"),
+    UNGDOMSYTELSE("ungdomsytelse-soknad")
+    ;
 
     companion object {
         fun fraMDC(): Ytelse {

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelsesøknadController.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelsesøknadController.kt
@@ -1,0 +1,58 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.api
+
+import jakarta.validation.Valid
+import kotlinx.coroutines.runBlocking
+import no.nav.brukerdialog.domenetjenester.innsending.InnsendingCache
+import no.nav.brukerdialog.domenetjenester.innsending.InnsendingService
+import no.nav.brukerdialog.metrikk.MetrikkService
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.Ungdomsytelsesøknad
+import no.nav.brukerdialog.common.MetaInfo
+import no.nav.brukerdialog.common.formaterStatuslogging
+import no.nav.brukerdialog.config.Issuers
+import no.nav.brukerdialog.utils.MDCUtil
+import no.nav.brukerdialog.utils.NavHeaders
+import no.nav.brukerdialog.utils.TokenUtils.personIdent
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.api.RequiredIssuers
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/ungdomsytelse")
+@RequiredIssuers(
+    ProtectedWithClaims(issuer = Issuers.TOKEN_X, claimMap = ["acr=Level4"])
+)
+class UngdomsytelsesøknadController(
+    private val innsendingService: InnsendingService,
+    private val innsendingCache: InnsendingCache,
+    private val springTokenValidationContextHolder: SpringTokenValidationContextHolder,
+    private val metrikkService: MetrikkService,
+) {
+    private companion object {
+        private val logger: Logger = LoggerFactory.getLogger(UngdomsytelsesøknadController::class.java)
+    }
+
+    @PostMapping("/soknad/innsending")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    fun innsending(
+        @RequestHeader(NavHeaders.BRUKERDIALOG_YTELSE) ytelse: String,
+        @RequestHeader(NavHeaders.BRUKERDIALOG_GIT_SHA) gitSha: String,
+        @Valid @RequestBody søknad: Ungdomsytelsesøknad,
+    ) = runBlocking {
+        val metadata = MetaInfo(correlationId = MDCUtil.callIdOrNew(), soknadDialogCommitSha = gitSha)
+        val cacheKey = "${springTokenValidationContextHolder.personIdent()}_${søknad.ytelse()}"
+
+        logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
+        innsendingCache.put(cacheKey)
+        innsendingService.registrer(søknad, metadata)
+        metrikkService.registrerMottattSøknad(søknad.ytelse())
+    }
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelsesøknadController.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelsesøknadController.kt
@@ -17,7 +17,9 @@ import no.nav.security.token.support.core.api.RequiredIssuers
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
+import org.springframework.web.ErrorResponseException
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -45,8 +47,13 @@ class UngdomsytelsesøknadController(
     fun innsending(
         @RequestHeader(NavHeaders.BRUKERDIALOG_YTELSE) ytelse: String,
         @RequestHeader(NavHeaders.BRUKERDIALOG_GIT_SHA) gitSha: String,
+        @Value("\${ENABLE_UNDOMSYTELSE:false}") enabled: Boolean? = null,
         @Valid @RequestBody søknad: Ungdomsytelsesøknad,
     ) = runBlocking {
+        if (enabled != true) {
+            logger.info("Ungdomsytelse er ikke aktivert.")
+            throw ErrorResponseException(HttpStatus.NOT_IMPLEMENTED)
+        }
         val metadata = MetaInfo(correlationId = MDCUtil.callIdOrNew(), soknadDialogCommitSha = gitSha)
         val cacheKey = "${springTokenValidationContextHolder.personIdent()}_${søknad.ytelse()}"
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/UngdomsytelseKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/UngdomsytelseKomplettSøknad.kt
@@ -1,0 +1,19 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene
+
+import no.nav.brukerdialog.domenetjenester.innsending.KomplettInnsending
+import no.nav.brukerdialog.oppslag.soker.Søker
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import no.nav.k9.søknad.Søknad as K9Søknad
+
+class UngdomsytelseKomplettSøknad(
+    private val søknadId: String,
+    private val søker: Søker,
+    private val språk: String,
+    private val fraOgMed: LocalDate,
+    private val tilOgMed: LocalDate,
+    private val mottatt: ZonedDateTime,
+    private val harForståttRettigheterOgPlikter: Boolean,
+    private val harBekreftetOpplysninger: Boolean,
+    private val k9Format: K9Søknad,
+) : KomplettInnsending

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/Ungdomsytelsesøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/Ungdomsytelsesøknad.kt
@@ -1,0 +1,82 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene
+
+import jakarta.validation.constraints.AssertTrue
+import no.nav.brukerdialog.common.MetaInfo
+import no.nav.brukerdialog.domenetjenester.innsending.Innsending
+import no.nav.brukerdialog.oppslag.soker.Søker
+import no.nav.brukerdialog.ytelse.Ytelse
+import no.nav.k9.søknad.Søknad
+import no.nav.k9.søknad.SøknadValidator
+import no.nav.k9.søknad.felles.Kildesystem
+import no.nav.k9.søknad.felles.Versjon
+import no.nav.k9.søknad.felles.type.Periode
+import no.nav.k9.søknad.felles.type.SøknadId
+import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
+import no.nav.k9.søknad.ytelse.ung.v1.UngdomsytelseSøknadValidator
+import java.net.URL
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import java.util.*
+import no.nav.k9.søknad.Søknad as K9Søknad
+
+data class Ungdomsytelsesøknad(
+    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'") internal val søknadId: String = UUID.randomUUID()
+        .toString(),
+    val språk: String,
+    val mottatt: ZonedDateTime,
+    val fraOgMed: LocalDate,
+    val tilOgMed: LocalDate,
+
+    val søkerNorskIdent: String,
+
+    @field:AssertTrue(message = "Opplysningene må bekreftes for å sende inn søknad")
+    val harBekreftetOpplysninger: Boolean,
+
+    @field:AssertTrue(message = "Må ha forstått rettigheter og plikter for å sende inn søknad")
+    val harForståttRettigheterOgPlikter: Boolean,
+
+    ) : Innsending {
+    companion object {
+        private val K9_SØKNAD_VERSJON = Versjon.of("1.0.0")
+    }
+
+    override fun somKomplettSøknad(
+        søker: Søker,
+        k9Format: no.nav.k9.søknad.Innsending?,
+        titler: List<String>,
+    ): UngdomsytelseKomplettSøknad {
+        requireNotNull(k9Format)
+        return UngdomsytelseKomplettSøknad(
+            søknadId = søknadId,
+            mottatt = mottatt,
+            søker = søker,
+            språk = språk,
+            fraOgMed = fraOgMed,
+            tilOgMed = tilOgMed,
+            harForståttRettigheterOgPlikter = harForståttRettigheterOgPlikter,
+            harBekreftetOpplysninger = harBekreftetOpplysninger,
+            k9Format = k9Format as Søknad
+        )
+    }
+
+    override fun valider() = mutableListOf<String>()
+
+    override fun somK9Format(søker: Søker, metadata: MetaInfo): K9Søknad {
+        val ytelse = Ungdomsytelse()
+            .medSøknadsperiode(Periode(fraOgMed, tilOgMed))
+
+        return K9Søknad()
+            .medVersjon(K9_SØKNAD_VERSJON)
+            .medMottattDato(mottatt)
+            .medSøknadId(SøknadId(søknadId))
+            .medSøker(søker.somK9Søker())
+            .medYtelse(ytelse)
+            .medKildesystem(Kildesystem.SØKNADSDIALOG)
+    }
+
+    override fun søkerNorskIdent(): String? = søkerNorskIdent
+    override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE
+    override fun søknadId(): String = søknadId
+    override fun vedlegg(): List<URL> = mutableListOf()
+    override fun søknadValidator(): SøknadValidator<Søknad> = UngdomsytelseSøknadValidator()
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/Ungdomsytelsesøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/Ungdomsytelsesøknad.kt
@@ -20,7 +20,7 @@ import java.util.*
 import no.nav.k9.søknad.Søknad as K9Søknad
 
 data class Ungdomsytelsesøknad(
-    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'") internal val søknadId: String = UUID.randomUUID()
+    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'") val søknadId: String = UUID.randomUUID()
         .toString(),
     val språk: String,
     val mottatt: ZonedDateTime,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/Ungdomsytelsesøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/Ungdomsytelsesøknad.kt
@@ -15,6 +15,7 @@ import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
 import no.nav.k9.søknad.ytelse.ung.v1.UngdomsytelseSøknadValidator
 import java.net.URL
 import java.time.LocalDate
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.util.*
 import no.nav.k9.søknad.Søknad as K9Søknad
@@ -23,7 +24,7 @@ data class Ungdomsytelsesøknad(
     @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'") val søknadId: String = UUID.randomUUID()
         .toString(),
     val språk: String,
-    val mottatt: ZonedDateTime,
+    val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate,
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseSøknadTopologyConfiguration.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseSøknadTopologyConfiguration.kt
@@ -1,0 +1,116 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.micrometer.core.instrument.MeterRegistry
+import no.nav.brukerdialog.kafka.config.KafkaProperties
+import no.nav.brukerdialog.kafka.config.KafkaStreamName
+import no.nav.brukerdialog.kafka.config.KafkaStreamsConfigUtils
+import no.nav.brukerdialog.kafka.config.KafkaStreamsConfigUtils.configure
+import no.nav.brukerdialog.kafka.config.SerDes
+import no.nav.brukerdialog.kafka.config.Topic
+import no.nav.brukerdialog.kafka.types.Cleanup
+import no.nav.brukerdialog.kafka.types.TopicEntry
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene.UngdomsytelsesøknadMottatt
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene.UngdomsytelsesøknadPreprosessertSøknad
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.KafkaStreamsConfiguration
+import org.springframework.kafka.config.StreamsBuilderFactoryBean
+
+@Configuration
+class UngdomsytelsesøknadTopologyConfiguration(
+    private val objectMapper: ObjectMapper,
+    private val meterRegistry: MeterRegistry,
+    private val kafkaProperties: KafkaProperties,
+) {
+    companion object {
+        const val UNGDOMSYTELSE_SØKNAD_PREPROSESSERING_STREAMS_BUILDER_NAME =
+            "ungdomsytelseSøknadPreprosesseringStreamsBuilder"
+        const val UNGDOMSYTELSE_SØKNAD_JOURNALFØRING_STREAMS_BUILDER_NAME =
+            "ungdomsytelseSøknadJournalføringStreamsBuilder"
+        const val UNGDOMSYTELSE_SØKNAD_CLEANUP_STREAMS_BUILDER_NAME = "ungdomsytelseSøknadCleanupStreamsBuilder"
+
+        const val UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC = "dusseldorf.ungdomsytelse-soknad-mottatt"
+        const val UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC = "dusseldorf.ungdomsytelse-soknad-preprosessert"
+        const val UNGDOMSYTELSE_SØKNAD_CLEANUP_TOPIC = "dusseldorf.ungdomsytelse-soknad-cleanup"
+    }
+
+    @Bean(name = [UNGDOMSYTELSE_SØKNAD_PREPROSESSERING_STREAMS_BUILDER_NAME])
+    fun preprosesseringStreamBuilder(): StreamsBuilderFactoryBean {
+        val streamPropertyKey = KafkaStreamName.UNGDOMSYTELSE_SØKNAD_PREPROSESSERING
+        val props = KafkaStreamsConfigUtils.commonStreamsConfigProperties(kafkaProperties, streamPropertyKey)
+        val streamsBuilderFactoryBean = StreamsBuilderFactoryBean(KafkaStreamsConfiguration(props))
+        streamsBuilderFactoryBean.configure(streamPropertyKey, meterRegistry)
+        return streamsBuilderFactoryBean
+    }
+
+    @Bean(name = [UNGDOMSYTELSE_SØKNAD_JOURNALFØRING_STREAMS_BUILDER_NAME])
+    fun journalføringStreamBuilder(): StreamsBuilderFactoryBean {
+        val streamPropertyKey = KafkaStreamName.UNGDOMSYTELSE_SØKNAD_JOURNALFØRING
+        val props = KafkaStreamsConfigUtils.commonStreamsConfigProperties(kafkaProperties, streamPropertyKey)
+        val streamsBuilderFactoryBean = StreamsBuilderFactoryBean(KafkaStreamsConfiguration(props))
+        streamsBuilderFactoryBean.configure(streamPropertyKey, meterRegistry)
+        return streamsBuilderFactoryBean
+    }
+
+    @Bean(name = [UNGDOMSYTELSE_SØKNAD_CLEANUP_STREAMS_BUILDER_NAME])
+    fun cleanupStreamBuilder(): StreamsBuilderFactoryBean {
+        val streamPropertyKey = KafkaStreamName.UNGDOMSYTELSE_SØKNAD_CLEANUP
+        val props = KafkaStreamsConfigUtils.commonStreamsConfigProperties(kafkaProperties, streamPropertyKey)
+        val streamsBuilderFactoryBean = StreamsBuilderFactoryBean(KafkaStreamsConfiguration(props))
+        streamsBuilderFactoryBean.configure(streamPropertyKey, meterRegistry)
+        return streamsBuilderFactoryBean
+    }
+
+    @Bean
+    fun ungdomsytelsesøknadMottattTopic(): Topic<TopicEntry<UngdomsytelsesøknadMottatt>> {
+        return Topic(
+            name = UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC,
+            serDes = UngdomsytelseMottattSøknadSerdes(objectMapper)
+        )
+    }
+
+    @Bean
+    fun ungdomsytelsesøknadPreprosessertTopic(): Topic<TopicEntry<UngdomsytelsesøknadPreprosessertSøknad>> {
+        return Topic(
+            name = UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC,
+            serDes = UngdomsytelsePreprosessertSøknadSerdes(objectMapper)
+        )
+    }
+
+    @Bean
+    fun ungdomsytelsesøknadCleanupTopic(): Topic<TopicEntry<Cleanup<UngdomsytelsesøknadPreprosessertSøknad>>> {
+        return Topic(
+            name = UNGDOMSYTELSE_SØKNAD_CLEANUP_TOPIC,
+            serDes = UngdomsytelseCleanupSøknadSerdes(objectMapper)
+        )
+    }
+}
+
+class UngdomsytelseMottattSøknadSerdes(
+    private val objectMapper: ObjectMapper,
+) : SerDes<TopicEntry<UngdomsytelsesøknadMottatt>>(objectMapper) {
+    override fun deserialize(topic: String, data: ByteArray): TopicEntry<UngdomsytelsesøknadMottatt> {
+        return objectMapper.readValue(data)
+    }
+}
+
+class UngdomsytelsePreprosessertSøknadSerdes(
+    private val objectMapper: ObjectMapper,
+) : SerDes<TopicEntry<UngdomsytelsesøknadPreprosessertSøknad>>(objectMapper) {
+    override fun deserialize(topic: String, data: ByteArray): TopicEntry<UngdomsytelsesøknadPreprosessertSøknad> {
+        return objectMapper.readValue(data)
+    }
+}
+
+class UngdomsytelseCleanupSøknadSerdes(
+    private val objectMapper: ObjectMapper,
+) : SerDes<TopicEntry<Cleanup<UngdomsytelsesøknadPreprosessertSøknad>>>(objectMapper) {
+    override fun deserialize(
+        topic: String,
+        data: ByteArray,
+    ): TopicEntry<Cleanup<UngdomsytelsesøknadPreprosessertSøknad>> {
+        return objectMapper.readValue(data)
+    }
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadCleanup.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadCleanup.kt
@@ -1,0 +1,63 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.kafka
+
+import no.nav.brukerdialog.dittnavvarsel.K9Beskjed
+import no.nav.brukerdialog.domenetjenester.mottak.CleanupService
+import no.nav.brukerdialog.kafka.config.KafkaStreamName
+import no.nav.brukerdialog.kafka.config.Topic
+import no.nav.brukerdialog.kafka.processors.LoggingToMDCProcessor
+import no.nav.brukerdialog.kafka.processors.process
+import no.nav.brukerdialog.kafka.types.Cleanup
+import no.nav.brukerdialog.kafka.types.TopicEntry
+import no.nav.brukerdialog.utils.HealthIndicatorUtils
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_CLEANUP_STREAMS_BUILDER_NAME
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene.UngdomsytelsesøknadPreprosessertSøknad
+import org.apache.kafka.streams.StreamsBuilder
+import org.apache.kafka.streams.kstream.KStream
+import org.apache.kafka.streams.processor.api.ProcessorSupplier
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.context.annotation.Bean
+import org.springframework.kafka.config.StreamsBuilderFactoryBean
+import org.springframework.retry.support.RetryTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class UngdomsytelsesøknadCleanup(
+    private val cleanupService: CleanupService<UngdomsytelsesøknadPreprosessertSøknad>,
+    private val ungdomsytelsesøknadCleanupTopic: Topic<TopicEntry<Cleanup<UngdomsytelsesøknadPreprosessertSøknad>>>,
+    private val k9DittnavVarselTopic: Topic<TopicEntry<K9Beskjed>>,
+    private val retryTemplate: RetryTemplate,
+    @Qualifier(UNGDOMSYTELSE_SØKNAD_CLEANUP_STREAMS_BUILDER_NAME) private val streamsBuilder: StreamsBuilder,
+    @Qualifier(UNGDOMSYTELSE_SØKNAD_CLEANUP_STREAMS_BUILDER_NAME) private val streamsBuilderFactoryBean: StreamsBuilderFactoryBean,
+) : HealthIndicator {
+
+    private companion object {
+        private val STREAM_NAME = KafkaStreamName.UNGDOMSYTELSE_SØKNAD_CLEANUP
+        private val logger = LoggerFactory.getLogger(UngdomsytelsesøknadCleanup::class.java)
+    }
+
+    @Bean
+    fun ungdomsytelsesøknadCleanupStream(): KStream<String, TopicEntry<Cleanup<UngdomsytelsesøknadPreprosessertSøknad>>> {
+        val stream: KStream<String, TopicEntry<Cleanup<UngdomsytelsesøknadPreprosessertSøknad>>> =
+            streamsBuilder.stream(ungdomsytelsesøknadCleanupTopic.name, ungdomsytelsesøknadCleanupTopic.consumedWith)
+
+        stream
+            .process(ProcessorSupplier { LoggingToMDCProcessor() })
+            .mapValues { _: String, value: TopicEntry<Cleanup<UngdomsytelsesøknadPreprosessertSøknad>> ->
+                process(name = STREAM_NAME, entry = value, retryTemplate = retryTemplate, logger = logger) {
+                    val cleanup = cleanupService.cleanup(value.data)
+
+                    logger.info("Sender K9Beskjed viderer til ${k9DittnavVarselTopic.name}")
+                    cleanup.melding.tilK9DittnavVarsel(value.metadata)
+                }
+            }
+            .to(k9DittnavVarselTopic.name, k9DittnavVarselTopic.producedWith)
+
+        return stream
+    }
+
+    override fun health(): Health =
+        HealthIndicatorUtils.resolveKafkaStreamHealth(STREAM_NAME, streamsBuilderFactoryBean)
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadJournalføring.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadJournalføring.kt
@@ -1,0 +1,61 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.kafka
+
+import no.nav.brukerdialog.domenetjenester.mottak.JournalføringsService
+import no.nav.brukerdialog.kafka.config.KafkaStreamName
+import no.nav.brukerdialog.kafka.config.Topic
+import no.nav.brukerdialog.kafka.processors.LoggingToMDCProcessor
+import no.nav.brukerdialog.kafka.processors.process
+import no.nav.brukerdialog.kafka.types.Cleanup
+import no.nav.brukerdialog.kafka.types.TopicEntry
+import no.nav.brukerdialog.utils.HealthIndicatorUtils
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_JOURNALFØRING_STREAMS_BUILDER_NAME
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene.UngdomsytelsesøknadPreprosessertSøknad
+import org.apache.kafka.streams.StreamsBuilder
+import org.apache.kafka.streams.kstream.KStream
+import org.apache.kafka.streams.processor.api.ProcessorSupplier
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.context.annotation.Bean
+import org.springframework.kafka.config.StreamsBuilderFactoryBean
+import org.springframework.retry.support.RetryTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class UngdomsytelsesøknadJournalføring(
+    private val journalføringsService: JournalføringsService,
+    private val ungdomsytelsesøknadPreprosessertTopic: Topic<TopicEntry<UngdomsytelsesøknadPreprosessertSøknad>>,
+    private val ungdomsytelsesøknadCleanupTopic: Topic<TopicEntry<Cleanup<UngdomsytelsesøknadPreprosessertSøknad>>>,
+    private val retryTemplate: RetryTemplate,
+    @Qualifier(UNGDOMSYTELSE_SØKNAD_JOURNALFØRING_STREAMS_BUILDER_NAME) private val streamsBuilder: StreamsBuilder,
+    @Qualifier(UNGDOMSYTELSE_SØKNAD_JOURNALFØRING_STREAMS_BUILDER_NAME) private val streamsBuilderFactoryBean: StreamsBuilderFactoryBean,
+) : HealthIndicator {
+
+    private companion object {
+        private val STREAM_NAME = KafkaStreamName.UNGDOMSYTELSE_SØKNAD_JOURNALFØRING
+        private val logger = LoggerFactory.getLogger(UngdomsytelsesøknadJournalføring::class.java)
+    }
+
+    @Bean
+    fun ungdomsytelsesøknadJournalføringsStream(): KStream<String, TopicEntry<UngdomsytelsesøknadPreprosessertSøknad>> {
+        val stream = streamsBuilder
+            .stream(ungdomsytelsesøknadPreprosessertTopic.name, ungdomsytelsesøknadPreprosessertTopic.consumedWith)
+
+        stream
+            .process(ProcessorSupplier { LoggingToMDCProcessor() })
+            .mapValues { _: String, value: TopicEntry<UngdomsytelsesøknadPreprosessertSøknad> ->
+                process(name = STREAM_NAME, entry = value, retryTemplate = retryTemplate, logger = logger) {
+                    val preprosessertSøknad = value.data
+                    val journalførSøknad = journalføringsService.journalfør(preprosessertSøknad)
+                    Cleanup(value.metadata, preprosessertSøknad, journalførSøknad)
+                }
+            }
+            .to(ungdomsytelsesøknadCleanupTopic.name, ungdomsytelsesøknadCleanupTopic.producedWith)
+
+        return stream
+    }
+
+    override fun health(): Health =
+        HealthIndicatorUtils.resolveKafkaStreamHealth(STREAM_NAME, streamsBuilderFactoryBean)
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadPreprosessering.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadPreprosessering.kt
@@ -1,0 +1,62 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.kafka
+
+import no.nav.brukerdialog.domenetjenester.mottak.PreprosesseringsService
+import no.nav.brukerdialog.kafka.config.KafkaStreamName
+import no.nav.brukerdialog.kafka.config.Topic
+import no.nav.brukerdialog.kafka.processors.LoggingToMDCProcessor
+import no.nav.brukerdialog.kafka.processors.process
+import no.nav.brukerdialog.kafka.types.TopicEntry
+import no.nav.brukerdialog.utils.HealthIndicatorUtils
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_PREPROSESSERING_STREAMS_BUILDER_NAME
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene.UngdomsytelsesøknadMottatt
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene.UngdomsytelsesøknadPreprosessertSøknad
+import org.apache.kafka.streams.StreamsBuilder
+import org.apache.kafka.streams.kstream.KStream
+import org.apache.kafka.streams.processor.api.ProcessorSupplier
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.context.annotation.Bean
+import org.springframework.kafka.config.StreamsBuilderFactoryBean
+import org.springframework.retry.support.RetryTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class UngdomsytelsesøknadPreprosessering(
+    private val preprosesseringsService: PreprosesseringsService,
+    private val ungdomsytelsesøknadMottattTopic: Topic<TopicEntry<UngdomsytelsesøknadMottatt>>,
+    private val ungdomsytelsesøknadPreprosessertTopic: Topic<TopicEntry<UngdomsytelsesøknadPreprosessertSøknad>>,
+    private val retryTemplate: RetryTemplate,
+    @Qualifier(UNGDOMSYTELSE_SØKNAD_PREPROSESSERING_STREAMS_BUILDER_NAME) private val streamsBuilder: StreamsBuilder,
+    @Qualifier(UNGDOMSYTELSE_SØKNAD_PREPROSESSERING_STREAMS_BUILDER_NAME) private val streamsBuilderFactoryBean: StreamsBuilderFactoryBean,
+) : HealthIndicator {
+
+    private companion object {
+        private val STREAM_NAME = KafkaStreamName.UNGDOMSYTELSE_SØKNAD_PREPROSESSERING
+        private val logger = LoggerFactory.getLogger(UngdomsytelsesøknadPreprosessering::class.java)
+    }
+
+    @Bean
+    fun ungdomsytelsesøknadPreprosesseringsStream(): KStream<String, TopicEntry<UngdomsytelsesøknadMottatt>> {
+        val stream: KStream<String, TopicEntry<UngdomsytelsesøknadMottatt>> = streamsBuilder
+            .stream(ungdomsytelsesøknadMottattTopic.name, ungdomsytelsesøknadMottattTopic.consumedWith)
+
+        stream
+            .process(ProcessorSupplier { LoggingToMDCProcessor<UngdomsytelsesøknadMottatt>() })
+            .mapValues { _: String, value: TopicEntry<UngdomsytelsesøknadMottatt> ->
+                process(name = STREAM_NAME, entry = value, retryTemplate = retryTemplate, logger = logger) {
+                    val søknad = value.data
+                    val preprosesseringsResultat =
+                        preprosesseringsService.preprosesser(søknad.mapTilPreprosesseringsData())
+
+                    søknad.mapTilPreprosessert(preprosesseringsResultat.dokumenter)
+                }
+            }
+            .to(ungdomsytelsesøknadPreprosessertTopic.name, ungdomsytelsesøknadPreprosessertTopic.producedWith)
+        return stream
+    }
+
+    override fun health(): Health =
+        HealthIndicatorUtils.resolveKafkaStreamHealth(STREAM_NAME, streamsBuilderFactoryBean)
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/domene/UngdomsytelsesøknadMottatt.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/domene/UngdomsytelsesøknadMottatt.kt
@@ -1,0 +1,50 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene
+
+import no.nav.k9.søknad.Søknad
+import no.nav.brukerdialog.common.Ytelse
+import no.nav.brukerdialog.domenetjenester.mottak.MottattMelding
+import no.nav.brukerdialog.domenetjenester.mottak.PreprosesseringsData
+import no.nav.brukerdialog.ytelse.fellesdomene.Søker
+import no.nav.brukerdialog.ytelse.ungdomsytelse.pdf.UngdomsytelsesøknadPdfData
+import no.nav.brukerdialog.pdf.PdfData
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+data class UngdomsytelsesøknadMottatt(
+    val søknadId: String,
+    val mottatt: ZonedDateTime,
+    val språk: String? = "nb",
+    val søker: Søker,
+    val fraOgMed: LocalDate,
+    val tilOgMed: LocalDate,
+    val k9Format: Søknad,
+    val harForståttRettigheterOgPlikter: Boolean,
+    val harBekreftetOpplysninger: Boolean,
+): MottattMelding {
+    override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE
+
+    override fun søkerFødselsnummer(): String = søker.fødselsnummer
+
+    override fun k9FormatSøknad(): Søknad = k9Format
+
+    override fun vedleggId(): List<String> = listOf()
+
+    override fun fødselsattestVedleggId(): List<String> = listOf()
+
+    override fun mapTilPreprosessert(dokumentId: List<List<String>>) = UngdomsytelsesøknadPreprosessertSøknad(
+        ungdomsytelseSøknadMottatt = this,
+        dokumentId = dokumentId
+    )
+
+    override fun pdfData(): PdfData = UngdomsytelsesøknadPdfData(this)
+
+    override fun mapTilPreprosesseringsData(): PreprosesseringsData = PreprosesseringsData(
+        søkerFødselsnummer = søkerFødselsnummer(),
+        k9FormatSøknad = k9FormatSøknad(),
+        vedleggId = vedleggId(),
+        fødselsattestVedleggId = fødselsattestVedleggId(),
+        pdfData = pdfData(),
+        pdfJournalføringsTittel = ytelse().tittel,
+        jsonJournalføringsTittel = "${ytelse().tittel}(JSON)",
+    )
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/domene/UngdomsytelsesøknadPreprosessertSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/domene/UngdomsytelsesøknadPreprosessertSøknad.kt
@@ -1,0 +1,74 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene
+
+import no.nav.brukerdialog.common.MetaInfo
+import no.nav.brukerdialog.common.Ytelse
+import no.nav.brukerdialog.dittnavvarsel.K9Beskjed
+import no.nav.brukerdialog.domenetjenester.mottak.Preprosessert
+import no.nav.brukerdialog.integrasjon.k9joark.JournalføringsRequest
+import no.nav.brukerdialog.ytelse.fellesdomene.Navn
+import no.nav.brukerdialog.ytelse.fellesdomene.Søker
+import no.nav.k9.søknad.Søknad
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import java.util.*
+import no.nav.k9.søknad.Søknad as K9Søknad
+
+data class UngdomsytelsesøknadPreprosessertSøknad(
+    val søknadId: String,
+    val mottatt: ZonedDateTime,
+    val språk: String?,
+    val søker: Søker,
+    val fraOgMed: LocalDate,
+    val tilOgMed: LocalDate,
+    val dokumentId: List<List<String>>,
+    val k9Format: K9Søknad,
+    val harForståttRettigheterOgPlikter: Boolean,
+    val harBekreftetOpplysninger: Boolean,
+) : Preprosessert {
+    internal constructor(
+        ungdomsytelseSøknadMottatt: UngdomsytelsesøknadMottatt,
+        dokumentId: List<List<String>>,
+    ) : this(
+        språk = ungdomsytelseSøknadMottatt.språk,
+        søknadId = ungdomsytelseSøknadMottatt.søknadId,
+        mottatt = ungdomsytelseSøknadMottatt.mottatt,
+        søker = ungdomsytelseSøknadMottatt.søker,
+        fraOgMed = ungdomsytelseSøknadMottatt.fraOgMed,
+        tilOgMed = ungdomsytelseSøknadMottatt.tilOgMed,
+        dokumentId = dokumentId,
+        k9Format = ungdomsytelseSøknadMottatt.k9Format,
+        harForståttRettigheterOgPlikter = ungdomsytelseSøknadMottatt.harForståttRettigheterOgPlikter,
+        harBekreftetOpplysninger = ungdomsytelseSøknadMottatt.harBekreftetOpplysninger
+    )
+
+    override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE
+
+    override fun mottattDato(): ZonedDateTime = mottatt
+
+    override fun søkerNavn(): Navn = Navn(søker.fornavn, søker.mellomnavn, søker.etternavn)
+
+    override fun søkerFødselsnummer(): String = søker.fødselsnummer
+
+    override fun k9FormatSøknad(): Søknad = k9Format
+
+    override fun dokumenter(): List<List<String>> = dokumentId
+
+    override fun tilJournaførigsRequest(): JournalføringsRequest = JournalføringsRequest(
+        ytelse = ytelse(),
+        norskIdent = søkerFødselsnummer(),
+        sokerNavn = søkerNavn(),
+        mottatt = mottatt,
+        dokumentId = dokumenter()
+    )
+
+    override fun tilK9DittnavVarsel(metadata: MetaInfo): K9Beskjed = K9Beskjed(
+        metadata = metadata,
+        grupperingsId = søknadId,
+        tekst = "Søknad om ungdomsytelse er mottatt",
+        link = null,
+        dagerSynlig = 7,
+        søkerFødselsnummer = søkerFødselsnummer(),
+        eventId = UUID.randomUUID().toString(),
+        ytelse = "UNGDOMSYTELSE"
+    )
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
@@ -1,0 +1,33 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.pdf
+
+import no.nav.brukerdialog.common.Constants.DATE_FORMATTER
+import no.nav.brukerdialog.common.Constants.DATE_TIME_FORMATTER
+import no.nav.brukerdialog.common.Constants.OSLO_ZONE_ID
+import no.nav.brukerdialog.common.Ytelse
+import no.nav.brukerdialog.pdf.PdfData
+import no.nav.brukerdialog.utils.DateUtils.somNorskDag
+import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene.UngdomsytelsesøknadMottatt
+
+class UngdomsytelsesøknadPdfData(private val søknad: UngdomsytelsesøknadMottatt) : PdfData() {
+    override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE
+
+    override fun pdfData(): Map<String, Any?> = mapOf(
+        "tittel" to ytelse().tittel,
+        "søknadId" to søknad.søknadId,
+        "søknadMottattDag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
+        "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
+        "periode" to mapOf(
+            "fraOgMed" to DATE_FORMATTER.format(søknad.fraOgMed),
+            "tilOgMed" to DATE_FORMATTER.format(søknad.tilOgMed)
+        ),
+        "søker" to søknad.søker.somMap(),
+        "samtykke" to mapOf(
+            "harForståttRettigheterOgPlikter" to søknad.harForståttRettigheterOgPlikter,
+            "harBekreftetOpplysninger" to søknad.harBekreftetOpplysninger
+        ),
+        "hjelp" to mapOf(
+            "språk" to søknad.språk?.språkTilTekst()
+        )
+    )
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -208,6 +208,16 @@ no.nav:
         application-id-suffix: omp-ao-cleanup
         auto-offset-reset: earliest
 
+      ungdomsytelse-soknad-preprosessering:
+        application-id-suffix: ungdomsytelse-soknad-preprosessering
+        auto-offset-reset: earliest
+      ungdomsytelse-soknad-journalforing:
+        application-id-suffix: ungdomsytelse-soknad-journalforing
+        auto-offset-reset: earliest
+      ungdomsytelse-soknad-cleanup:
+        application-id-suffix: ungdomsytelse-soknad-cleanup-stream
+        auto-offset-reset: earliest
+
 management:
   endpoint:
     health:

--- a/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="NO">
+
+<head>
+    <meta charset="UTF-8"/>
+    <title>{{tittel}}</title>
+    <meta name="subject" content="{{tittel}}"/>
+    <meta name="author" content="nav.no"/>
+    <meta name="description"
+          content="{{tittel}} {{søknadMottattDag}} {{ søknadMottatt }}"/>
+    <bookmarks>
+        <bookmark name="Søker" href="#søker"/>
+        <bookmark name="Samtykke" href="#samtykke"/>
+        <bookmark name="vedlegg" href="#vedlegg"/>
+    </bookmarks>
+    {{#block 'style-common' }}
+    {{/block}}
+</head>
+
+<body>
+<h1 id="header">{{tittel}}</h1>
+<div class="nokkelinfo">
+    <p><strong>Sendt til NAV</strong> {{søknadMottattDag}} {{ søknadMottatt }}</p>
+    <p><strong>Språk:</strong> {{hjelp.språk}}</p>
+</div>
+<div class="innholdscontainer">
+    {{> partial/felles/personPartial id="søker" title="Søker" navn=søker.navn fødselsnummer=søker.fødselsnummer }}
+
+    <section id="vedlegg">
+        <h2>Vedlegg</h2>
+        {{#if pleietrengende.manglerNorskIdentitetsnummer}}
+            {{#if harLastetOppId}}
+                <p>Har lastet opp kopi av ID til pleietrengende.</p>
+            {{else}}
+                <p>Har ikke lastet opp kopi av ID til pleietrengende.</p>
+            {{/if}}
+        {{/if}}
+
+        {{#if harLastetOppLegeerklæring}}
+            <p>Har lastet opp legeerklæring.</p>
+        {{else}}
+            <p>Har ikke lastet opp legeerklæring.</p>
+        {{/if}}
+
+    </section>
+
+    <!-- SAMTYKKE -->
+    <section id="samtykke">
+        <h2>Samtykke fra deg</h2>
+        <p class="sporsmalstekst">Har du forstått dine rettigheter og plikter?</p>
+        <p>{{ jaNeiSvar samtykke.harForståttRettigheterOgPlikter }}</p>
+        <hr/>
+        <p class="sporsmalstekst">Har du bekreftet at opplysninger du har gitt er riktige?</p>
+        <p>{{ jaNeiSvar samtykke.harBekreftetOpplysninger }}</p>
+    </section>
+
+</div>
+
+<!-- FOOTER -->
+<p id="footer">
+    <span class="soknadsid">{{ søknadId }}</span>
+    <span class="soknadsid">{{ id }}</span>
+    <span class="sidetall">side <span id="pagenumber"></span> av <span id="pagecount"></span></span>
+</p>
+</body>
+
+</html>

--- a/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
@@ -11,7 +11,6 @@
     <bookmarks>
         <bookmark name="Søker" href="#søker"/>
         <bookmark name="Samtykke" href="#samtykke"/>
-        <bookmark name="vedlegg" href="#vedlegg"/>
     </bookmarks>
     {{#block 'style-common' }}
     {{/block}}
@@ -26,17 +25,6 @@
 <div class="innholdscontainer">
     {{> partial/felles/personPartial id="søker" title="Søker" navn=søker.navn fødselsnummer=søker.fødselsnummer }}
 
-    <section id="vedlegg">
-        <h2>Vedlegg</h2>
-        {{#if pleietrengende.manglerNorskIdentitetsnummer}}
-            {{#if harLastetOppId}}
-                <p>Har lastet opp kopi av ID til pleietrengende.</p>
-            {{else}}
-                <p>Har ikke lastet opp kopi av ID til pleietrengende.</p>
-            {{/if}}
-        {{/if}}
-    </section>
-
     <!-- SAMTYKKE -->
     <section id="samtykke">
         <h2>Samtykke fra deg</h2>
@@ -46,7 +34,6 @@
         <p class="sporsmalstekst">Har du bekreftet at opplysninger du har gitt er riktige?</p>
         <p>{{ jaNeiSvar samtykke.harBekreftetOpplysninger }}</p>
     </section>
-
 </div>
 
 <!-- FOOTER -->

--- a/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
@@ -35,13 +35,6 @@
                 <p>Har ikke lastet opp kopi av ID til pleietrengende.</p>
             {{/if}}
         {{/if}}
-
-        {{#if harLastetOppLegeerklæring}}
-            <p>Har lastet opp legeerklæring.</p>
-        {{else}}
-            <p>Har ikke lastet opp legeerklæring.</p>
-        {{/if}}
-
     </section>
 
     <!-- SAMTYKKE -->

--- a/src/test/kotlin/no/nav/brukerdialog/utils/MockMvcUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/utils/MockMvcUtils.kt
@@ -26,6 +26,7 @@ object MockMvcUtils {
             Ytelse.ETTERSENDING_OMP -> "/ettersending-omp"
             Ytelse.ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN -> "/endringsmelding-pleiepenger-sykt-barn"
             Ytelse.DINE_PLEIEPENGER -> "/dine-pleiepenger"
+            Ytelse.UNGDOMSYTELSE -> "/ungdomsytelse/soknad"
             Ytelse.OPPLARINGSPENGER -> TODO("Trenger endepunkt for opplæringspenger. Se K9-joark.")
         }
 

--- a/src/test/kotlin/no/nav/brukerdialog/utils/TestUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/utils/TestUtils.kt
@@ -32,6 +32,9 @@ import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.kafka.PILSTopolog
 import no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.kafka.PSBTopologyConfiguration.Companion.PSB_CLEANUP_TOPIC
 import no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.kafka.PSBTopologyConfiguration.Companion.PSB_MOTTATT_TOPIC
 import no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.kafka.PSBTopologyConfiguration.Companion.PSB_PREPROSESSERT_TOPIC
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_CLEANUP_TOPIC
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -118,6 +121,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
         OMP_AO_MOTTATT_TOPIC,
         OMP_AO_PREPROSESSERT_TOPIC,
         OMP_AO_CLEANUP_TOPIC,
+
+        // Ungdomsytelse
+        UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC,
+        UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC,
+        UNGDOMSYTELSE_SØKNAD_CLEANUP_TOPIC,
 
         // K9 Dittnav varsel
         K9_DITTNAV_VARSEL_TOPIC

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelsesøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelsesøknadControllerTest.kt
@@ -1,0 +1,150 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.coEvery
+import io.mockk.every
+import no.nav.brukerdialog.config.JacksonConfiguration
+import no.nav.brukerdialog.domenetjenester.innsending.InnsendingCache
+import no.nav.brukerdialog.domenetjenester.innsending.InnsendingService
+import no.nav.brukerdialog.integrasjon.k9selvbetjeningoppslag.BarnService
+import no.nav.brukerdialog.metrikk.MetrikkService
+import no.nav.brukerdialog.utils.CallIdGenerator
+import no.nav.brukerdialog.utils.NavHeaders
+import no.nav.brukerdialog.utils.TokenTestUtils.mockContext
+import no.nav.brukerdialog.ytelse.Ytelse
+import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.SøknadUtils
+import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.ArbeidIPeriode
+import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.Arbeidsforhold
+import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.Arbeidsgiver
+import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.Frilans
+import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.JobberIPeriodeSvar
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.Ungdomsytelsesøknad
+import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelsesøknadUtils
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.time.LocalDate
+import java.util.*
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(SpringExtension::class)
+@WebMvcTest(controllers = [UngdomsytelsesøknadController::class])
+@Import(
+    JacksonConfiguration::class,
+    CallIdGenerator::class
+)
+class UngdomsytelsesøknadControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
+    private lateinit var innsendingService: InnsendingService
+
+    @MockkBean
+    private lateinit var innsendingCache: InnsendingCache
+
+    @MockkBean
+    private lateinit var barnService: BarnService
+
+    @MockkBean
+    private lateinit var springTokenValidationContextHolder: SpringTokenValidationContextHolder
+
+    @MockkBean
+    private lateinit var metrikkService: MetrikkService
+
+    @BeforeEach
+    fun setUp() {
+        springTokenValidationContextHolder.mockContext()
+    }
+
+    @Test
+    fun `Innsending av søknad er OK`() {
+        coEvery { barnService.hentBarn() } returns emptyList()
+        every { innsendingCache.put(any()) } returns Unit
+        coEvery { innsendingService.registrer(any(), any()) } returns Unit
+        every { metrikkService.registrerMottattSøknad(any()) } returns Unit
+
+        val defaultSøknad = SøknadUtils.defaultSøknad
+
+        mockMvc.post("/ungdomsytelse/soknad/innsending") {
+            headers {
+                set(NavHeaders.BRUKERDIALOG_YTELSE, Ytelse.PLEIEPENGER_LIVETS_SLUTTFASE.dialog)
+                set(NavHeaders.BRUKERDIALOG_GIT_SHA, UUID.randomUUID().toString())
+            }
+            contentType = MediaType.APPLICATION_JSON
+            accept = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(defaultSøknad)
+        }
+            .andExpect {
+                status { isAccepted() }
+                header { exists(NavHeaders.X_CORRELATION_ID) }
+            }
+    }
+
+    @Test
+    fun `Innsending av søknad med feile verdier responderer med bad request`() {
+        val defaultSøknad: Ungdomsytelsesøknad = SøknadUtils.defaultSøknad
+
+        val jsonPayload = objectMapper.writeValueAsString(
+            defaultSøknad.copy(
+                harForståttRettigheterOgPlikter = false,
+                harBekreftetOpplysninger = false,
+            )
+        )
+        mockMvc.post("/ungdomsytelse/soknad/innsending") {
+            headers {
+                set(NavHeaders.BRUKERDIALOG_YTELSE, Ytelse.UNGDOMSYTELSE.dialog)
+                set(NavHeaders.BRUKERDIALOG_GIT_SHA, UUID.randomUUID().toString())
+            }
+            contentType = MediaType.APPLICATION_JSON
+            content = jsonPayload.trimIndent()
+        }
+            .andExpect {
+                status { isBadRequest() }
+                header { exists(NavHeaders.X_CORRELATION_ID) }
+                header { exists(NavHeaders.PROBLEM_DETAILS) }
+                content {
+                    json(
+                        """
+                        {
+                          "type": "/problem-details/invalid-request-parameters",
+                          "instance": "http://localhost/ungdomsytelse/soknad/innsending",
+                          "title": "invalid-request-parameters",
+                          "status": 400,
+                          "detail": "Forespørselen inneholder valideringsfeil",
+                          "violations": [
+                            {
+                              "invalidValue": false,
+                              "parameterName": "ungdomsytelsesøknad.harForståttRettigheterOgPlikter",
+                              "parameterType": "ENTITY",
+                              "reason": "Må ha forstått rettigheter og plikter for å sende inn søknad"
+                            },
+                            {
+                              "invalidValue": false,
+                              "parameterName": "ungdomsytelsesøknad.harBekreftetOpplysninger",
+                              "parameterType": "ENTITY",
+                              "reason": "Opplysningene må bekreftes for å sende inn søknad"
+                            },
+                          ]
+                        }
+                        """.trimIndent(),
+                        false,
+                    )
+                }
+            }
+    }
+}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelsesøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelsesøknadControllerTest.kt
@@ -38,7 +38,11 @@ import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(SpringExtension::class)
-@WebMvcTest(controllers = [UngdomsytelsesøknadController::class])
+@WebMvcTest(
+    controllers = [UngdomsytelsesøknadController::class],
+    properties = [
+        "ENABLE_UNDOMSYTELSE=true",
+    ])
 @Import(
     JacksonConfiguration::class,
     CallIdGenerator::class

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadKonsumentTest.kt
@@ -1,0 +1,151 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.kafka
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import no.nav.brukerdialog.AbstractIntegrationTest
+import no.nav.brukerdialog.common.MetaInfo
+import no.nav.brukerdialog.config.JacksonConfiguration
+import no.nav.brukerdialog.dittnavvarsel.DittnavVarselTopologyConfiguration
+import no.nav.brukerdialog.dittnavvarsel.K9Beskjed
+import no.nav.brukerdialog.kafka.types.TopicEntry
+import no.nav.brukerdialog.utils.KafkaUtils.leggPåTopic
+import no.nav.brukerdialog.utils.KafkaUtils.lesMelding
+import no.nav.brukerdialog.utils.MockMvcUtils.sendInnSøknad
+import no.nav.brukerdialog.utils.TokenTestUtils.hentToken
+import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.SøknadUtils
+import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelsesøknadUtils
+import org.intellij.lang.annotations.Language
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import java.net.URI
+import java.time.ZonedDateTime
+import java.util.*
+
+class UngdomsytelsesøknadKonsumentTest : AbstractIntegrationTest() {
+
+    override val consumerGroupPrefix = "ungdomsytelse-soknad"
+    override val consumerGroupTopics = listOf(
+        UngdomsytelsesøknadTopologyConfiguration.UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC,
+        UngdomsytelsesøknadTopologyConfiguration.UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC,
+        UngdomsytelsesøknadTopologyConfiguration.UNGDOMSYTELSE_SØKNAD_CLEANUP_TOPIC
+    )
+
+    @Test
+    fun `forvent at melding konsumeres riktig og dokumenter blir slettet`() {
+        val søker = mockSøker()
+        mockBarn()
+        mockLagreDokument()
+        mockJournalføring()
+
+        val søknadId = UUID.randomUUID().toString()
+        val søknad = SøknadUtils.defaultSøknad.copy(søknadId = søknadId)
+
+        mockMvc.sendInnSøknad(søknad, mockOAuth2Server.hentToken())
+
+        coVerify(exactly = 1, timeout = 120 * 1000) {
+            k9DokumentMellomlagringService.slettDokumenter(any(), any())
+        }
+
+        k9DittnavVarselConsumer.lesMelding(
+            key = søknadId,
+            topic = DittnavVarselTopologyConfiguration.K9_DITTNAV_VARSEL_TOPIC
+        ).value().assertDittnavVarsel(
+            K9Beskjed(
+                metadata = no.nav.brukerdialog.utils.SøknadUtils.metadata,
+                grupperingsId = søknadId,
+                tekst = "Søknad om ungdomsytelse er mottatt",
+                link = null,
+                dagerSynlig = 7,
+                søkerFødselsnummer = søker.fødselsnummer,
+                eventId = "testes ikke",
+                ytelse = "UNGDOMSYTELSE",
+            )
+        )
+    }
+
+    @Test
+    fun `Forvent at melding bli prosessert på 5 forsøk etter 4 feil`() {
+        val søknadId = UUID.randomUUID().toString()
+        val mottattString = "2020-01-01T10:30:15Z"
+        val mottatt = ZonedDateTime.parse(mottattString, JacksonConfiguration.zonedDateTimeFormatter)
+        val søknadMottatt = UngdomsytelsesøknadUtils.gyldigSøknad(søknadId = søknadId, mottatt = mottatt)
+        val correlationId = UUID.randomUUID().toString()
+        val metadata = MetaInfo(version = 1, correlationId = correlationId)
+        val topicEntry = TopicEntry(metadata, søknadMottatt)
+        val topicEntryJson = objectMapper.writeValueAsString(topicEntry)
+
+        coEvery { k9DokumentMellomlagringService.lagreDokument(any()) }
+            .throws(IllegalStateException("Feilet med lagring av dokument..."))
+            .andThenThrows(IllegalStateException("Feilet med lagring av dokument..."))
+            .andThenThrows(IllegalStateException("Feilet med lagring av dokument..."))
+            .andThenThrows(IllegalStateException("Feilet med lagring av dokument..."))
+            .andThenMany(listOf("123456789", "987654321").map { URI("http://localhost:8080/dokument/$it") })
+
+        producer.leggPåTopic(
+            key = søknadId,
+            value = topicEntryJson,
+            topic = UngdomsytelsesøknadTopologyConfiguration.UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC
+        )
+        val lesMelding =
+            consumer.lesMelding(key = søknadId, topic = UngdomsytelsesøknadTopologyConfiguration.UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC)
+                .value()
+
+        val preprosessertSøknadJson = JSONObject(lesMelding).getJSONObject("data").toString()
+        JSONAssert.assertEquals(preprosessertSøknadSomJson(søknadId, mottattString), preprosessertSøknadJson, true)
+    }
+    @Language("JSON")
+    private fun preprosessertSøknadSomJson(søknadId: String, mottatt: String) = """
+        {
+          "søknadId": "$søknadId",
+          "mottatt": "$mottatt",
+          "søker": {
+            "etternavn": "Nordmann",
+            "mellomnavn": "Mellomnavn",
+            "aktørId": "123456",
+            "fødselsdato": "2000-01-01",
+            "fornavn": "Ola",
+            "fødselsnummer": "02119970078"
+          },
+          "fraOgMed": "2022-01-01",
+          "tilOgMed": "2022-02-01",
+          "språk": "nb",
+          "harForståttRettigheterOgPlikter": true,
+          "dokumentId": [
+            [
+              "123456789",
+              "987654321"
+            ]
+          ],
+          "harBekreftetOpplysninger": true,
+          "k9Format": {
+            "språk": "nb",
+            "kildesystem": "søknadsdialog",
+            "mottattDato": "$mottatt",
+            "søknadId": "$søknadId",
+            "søker": {
+              "norskIdentitetsnummer": "02119970078"
+            },
+            "ytelse": {
+              "søknadsperiode": [],
+              "type": "UNGDOMSYTELSE"
+            },
+            "journalposter": [],
+            "begrunnelseForInnsending": {
+              "tekst": null
+            },
+            "versjon": "1.0.0"
+          }
+        }
+        """.trimIndent()
+
+
+    private fun String.assertDittnavVarsel(k9Beskjed: K9Beskjed) {
+        val k9BeskjedJson = JSONObject(this)
+        Assertions.assertEquals(k9Beskjed.grupperingsId, k9BeskjedJson.getString("grupperingsId"))
+        Assertions.assertEquals(k9Beskjed.tekst, k9BeskjedJson.getString("tekst"))
+        Assertions.assertEquals(k9Beskjed.ytelse, k9BeskjedJson.getString("ytelse"))
+        Assertions.assertEquals(k9Beskjed.dagerSynlig, k9BeskjedJson.getLong("dagerSynlig"))
+    }
+}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelesøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelesøknadPdfGeneratorTest.kt
@@ -1,0 +1,39 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.pdf
+
+import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelsesøknadUtils
+import no.nav.brukerdialog.meldinger.pleiepengerilivetsslutttfase.domene.FlereSokereSvar
+import no.nav.brukerdialog.meldinger.pleiepengerilivetsslutttfase.domene.Frilans
+import no.nav.brukerdialog.meldinger.pleiepengerilivetsslutttfase.domene.Land
+import no.nav.brukerdialog.meldinger.pleiepengerilivetsslutttfase.domene.Næringstype
+import no.nav.brukerdialog.meldinger.pleiepengerilivetsslutttfase.domene.Pleietrengende
+import no.nav.brukerdialog.meldinger.pleiepengerilivetsslutttfase.domene.UtenlandskNæring
+import no.nav.brukerdialog.meldinger.pleiepengerilivetsslutttfase.domene.ÅrsakManglerIdentitetsnummer
+import no.nav.brukerdialog.pdf.PDFGenerator
+import no.nav.brukerdialog.utils.PathUtils.pdfPath
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.LocalDate
+
+class UngdomsytelesøknadPdfGeneratorTest {
+
+    @Test
+    fun `generering av oppsummerings-PDF fungerer`() {
+        genererOppsummeringsPdfer(false)
+    }
+
+    @Test
+    fun `opprett lesbar oppsummerings-PDF`() {
+        genererOppsummeringsPdfer(true)
+    }
+
+    private companion object {
+        const val PDF_PREFIX = "ung"
+        val generator = PDFGenerator()
+
+        fun genererOppsummeringsPdfer(writeBytes: Boolean) {
+            var id = "1-full-søknad"
+            var pdf = generator.genererPDF(UngdomsytelsesøknadUtils.gyldigSøknad(søknadId = id).pdfData())
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/SøknadUtils.kt
@@ -1,0 +1,19 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.utils
+
+import no.nav.brukerdialog.config.JacksonConfiguration
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.Ungdomsytelsesøknad
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+object SøknadUtils {
+    internal val defaultSøknad = Ungdomsytelsesøknad(
+        søknadId = "4e62f8de-1ff6-40e9-bdcd-10485c789094",
+        mottatt = ZonedDateTime.parse("2022-01-02T03:04:05Z", JacksonConfiguration.zonedDateTimeFormatter),
+        språk = "nb",
+        søkerNorskIdent = "12345678910",
+        fraOgMed = LocalDate.parse("2021-01-01"),
+        tilOgMed = LocalDate.parse("2021-01-10"),
+        harForståttRettigheterOgPlikter = true,
+        harBekreftetOpplysninger = true
+    )
+}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
@@ -1,0 +1,49 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.utils
+
+import no.nav.brukerdialog.ytelse.fellesdomene.Søker
+import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene.UngdomsytelsesøknadMottatt
+import no.nav.k9.søknad.felles.Kildesystem
+import no.nav.k9.søknad.felles.Versjon
+import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer
+import no.nav.k9.søknad.felles.type.SøknadId
+import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.*
+import no.nav.k9.søknad.Søknad as k9FormatSøknad
+import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
+
+object UngdomsytelsesøknadUtils {
+
+    fun gyldigSøknad(
+        søkerFødselsnummer: String = "02119970078",
+        søknadId: String = UUID.randomUUID().toString(),
+        mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC"))
+    ) = UngdomsytelsesøknadMottatt(
+        språk = "nb",
+        søknadId = søknadId,
+        mottatt = mottatt,
+        søker = Søker(
+            aktørId = "123456",
+            fødselsnummer = søkerFødselsnummer,
+            fødselsdato = LocalDate.parse("2000-01-01"),
+            etternavn = "Nordmann",
+            mellomnavn = "Mellomnavn",
+            fornavn = "Ola"
+        ),
+        fraOgMed = LocalDate.parse("2022-01-01"),
+        tilOgMed = LocalDate.parse("2022-02-01"),
+        k9Format = gyldigK9Format(søknadId, mottatt),
+        harBekreftetOpplysninger = true,
+        harForståttRettigheterOgPlikter = true
+    )
+
+    fun gyldigK9Format(søknadId: String = UUID.randomUUID().toString(), mottatt: ZonedDateTime) = k9FormatSøknad(
+        SøknadId(søknadId),
+        Versjon("1.0.0"),
+        mottatt,
+        K9Søker(NorskIdentitetsnummer.of("02119970078")),
+        Ungdomsytelse()
+    ).medKildesystem(Kildesystem.SØKNADSDIALOG)
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -165,6 +165,13 @@ no.nav:
         application-id-suffix: omp-ao-cleanup
         auto-offset-reset: earliest
 
+      ungdomsytelse-soknad-preprosessering:
+        auto-offset-reset: earliest
+      ungdomsytelse-soknad-journalforing:
+        auto-offset-reset: earliest
+      ungdomsytelse-soknad-cleanup:
+        auto-offset-reset: earliest
+
 wiremock:
   reset-mappings-after-each-test: true
   server:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,6 +4,7 @@ K9_JOARK_BASE_URL: http://localhost:${wiremock.server.port:8083}/k9-joark-mock
 K9_SAK_INNSYN_API_BASE_URL: http://localhost:${wiremock.server.port:8083}/k9-sak-innsyn-api-mock
 K9_BRUKERDIALOG_CACHE_BASE_URL: http://localhost:${wiremock.server.port:8083}/k9-brukerdialog-cache-mock
 K9_SELVBETJENING_OPPSLAG_BASE_URL: http://localhost:${wiremock.server.port:8083}/k9-selvbetjening-oppslag-mock
+ENABLE_UNDOMSYTELSE: true
 
 no.nav:
   security.jwt:


### PR DESCRIPTION
## Infrastrukturendringer:
- Oppretter nye topics (mottatt, journalført, og cleanup) for søknaden.
- Legger til ny dialog (ungdomsytelse-soknad) i inbound rules for å tillate kall og henting av token.

## Kodeendringer
- Legger til nytt endepunkt for innsending av søknad, validering, mapping til k9-format og publisering på mottatt topic for prosessering.
- Legger til nye streams (preprosessert, journalført, og cleanup).
- Journalfører mot nytt endepunkt i k9-joark for ungdomsytelsen.

## Endepunkt for testing via Swagger:
https://k9-brukerdialog-prosessering.intern.dev.nav.no/swagger-ui/index.html#/ungdomsytelses-%C3%B8knad-controller/innsending

## Generert PDF for søknad:
![image](https://github.com/user-attachments/assets/02fa1554-84a8-4290-a286-bf64006e8471)

