### PR TITLE
Legger til oppsett for å kunne bruke nynorsk templates for søknads-pdfer.

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/common/Ytelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/common/Ytelse.kt
@@ -35,7 +35,7 @@ import no.nav.k9.søknad.felles.type.Språk
 enum class Ytelse(val tittel: String, val nynorskTittel: String? = null) {
     OMSORGSPENGER_UTVIDET_RETT(
         "Søknad om ekstra omsorgsdager for barn som har kronisk/langvarig sykdom eller funksjonshemning",
-        "Søknad om ekstra omsorgsdagar for barn som har kronisk/langvarig sjukdom eller funksjonshemning"
+        "Søknad om ekstra omsorgsdagar for barn som har kronisk/langvarig sjukdom eller funksjonshemming"
     ),
     OMSORGSPENGER_MIDLERTIDIG_ALENE("Søknad om ekstra omsorgsdager når den andre forelderen ikke kan ha tilsyn med barn"),
     ETTERSENDELSE("Ettersendelse av dokumentasjon"),

--- a/src/main/kotlin/no/nav/brukerdialog/common/Ytelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/common/Ytelse.kt
@@ -31,8 +31,11 @@ import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopolo
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC
 
-enum class Ytelse(val tittel: String) {
-    OMSORGSPENGER_UTVIDET_RETT("Søknad om ekstra omsorgsdager for barn som har kronisk/langvarig sykdom eller funksjonshemning"),
+enum class Ytelse(val tittel: String, val nynorskTittel: String? = null) {
+    OMSORGSPENGER_UTVIDET_RETT(
+        "Søknad om ekstra omsorgsdager for barn som har kronisk/langvarig sykdom eller funksjonshemning",
+        "Søknad om ekstra omsorgsdagar for barn som har kronisk/langvarig sjukdom eller funksjonshemning"
+    ),
     OMSORGSPENGER_MIDLERTIDIG_ALENE("Søknad om ekstra omsorgsdager når den andre forelderen ikke kan ha tilsyn med barn"),
     ETTERSENDELSE("Ettersendelse av dokumentasjon"),
     OMSORGSDAGER_ALENEOMSORG("Søknad om ekstra omsorgsdager ved aleneomsorg"),

--- a/src/main/kotlin/no/nav/brukerdialog/common/Ytelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/common/Ytelse.kt
@@ -30,6 +30,7 @@ import no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.kafka.PSBTopologyC
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_CLEANUP_TOPIC
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_MOTTATT_TOPIC
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.UngdomsytelsesøknadTopologyConfiguration.Companion.UNGDOMSYTELSE_SØKNAD_PREPROSESSERT_TOPIC
+import no.nav.k9.søknad.felles.type.Språk
 
 enum class Ytelse(val tittel: String, val nynorskTittel: String? = null) {
     OMSORGSPENGER_UTVIDET_RETT(
@@ -46,6 +47,11 @@ enum class Ytelse(val tittel: String, val nynorskTittel: String? = null) {
     PLEIEPENGER_SYKT_BARN_ENDRINGSMELDING("Endringsmelding for pleiepenger sykt barn"),
     UNGDOMSYTELSE("Søknad om ungdomsytelse")
     ;
+
+    fun utledTittel(språk: Språk): String = when (språk) {
+        Språk.NORSK_NYNORSK -> nynorskTittel ?: tittel
+        else -> tittel
+    }
 
     companion object {
         fun fraTopic(topic: String): Ytelse = when (topic) {

--- a/src/main/kotlin/no/nav/brukerdialog/pdf/PDFGenerator.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/pdf/PDFGenerator.kt
@@ -16,6 +16,7 @@ import no.nav.brukerdialog.common.Ytelse
 import no.nav.brukerdialog.meldinger.omsorgpengerutbetalingat.domene.FraværÅrsak
 import no.nav.brukerdialog.meldinger.omsorgpengerutbetalingsnf.domene.AktivitetFravær
 import no.nav.brukerdialog.utils.DurationUtils.tilString
+import no.nav.k9.søknad.felles.type.Språk
 import org.springframework.core.io.ClassPathResource
 import org.springframework.stereotype.Component
 import java.io.ByteArrayInputStream
@@ -230,17 +231,24 @@ class PDFGenerator {
 
 abstract class PdfData {
     abstract fun ytelse(): Ytelse
+    abstract fun språk(): Språk
     abstract fun pdfData(): Map<String, Any?>
-    fun resolveTemplate(): String = when (ytelse()) {
-        Ytelse.PLEIEPENGER_SYKT_BARN -> "pleiepenger-sykt-barn-soknad"
-        Ytelse.PLEIEPENGER_SYKT_BARN_ENDRINGSMELDING -> "pleiepenger-sykt-barn-endringsmelding"
-        Ytelse.PLEIEPENGER_LIVETS_SLUTTFASE -> "pleiepenger-i-livets-sluttfase-soknad"
-        Ytelse.OMSORGSPENGER_UTVIDET_RETT -> "omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad"
-        Ytelse.OMSORGSPENGER_MIDLERTIDIG_ALENE -> "omsorgspenger-midlertidig-alene-soknad"
-        Ytelse.OMSORGSDAGER_ALENEOMSORG -> "omsorgspenger-aleneomsorg-soknad"
-        Ytelse.OMSORGSPENGER_UTBETALING_ARBEIDSTAKER -> "omsorgspenger-utbetaling-arbeidstaker-soknad"
-        Ytelse.OMSORGSPENGER_UTBETALING_SNF -> "omsorgspenger-utbetaling-snf-soknad"
-        Ytelse.ETTERSENDELSE -> "ettersendelse"
-        Ytelse.UNGDOMSYTELSE -> "ungdomsytelse-soknad"
+    fun resolveTemplate(): String {
+        val språkSuffix = when (språk()) {
+            Språk.NORSK_NYNORSK -> ".nn"
+            else -> "" // Default bokmål
+        }
+        return when (ytelse()) {
+            Ytelse.PLEIEPENGER_SYKT_BARN -> "pleiepenger-sykt-barn-soknad$språkSuffix"
+            Ytelse.PLEIEPENGER_SYKT_BARN_ENDRINGSMELDING -> "pleiepenger-sykt-barn-endringsmelding$språkSuffix"
+            Ytelse.PLEIEPENGER_LIVETS_SLUTTFASE -> "pleiepenger-i-livets-sluttfase-soknad$språkSuffix"
+            Ytelse.OMSORGSPENGER_UTVIDET_RETT -> "omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad$språkSuffix"
+            Ytelse.OMSORGSPENGER_MIDLERTIDIG_ALENE -> "omsorgspenger-midlertidig-alene-soknad$språkSuffix"
+            Ytelse.OMSORGSDAGER_ALENEOMSORG -> "omsorgspenger-aleneomsorg-soknad$språkSuffix"
+            Ytelse.OMSORGSPENGER_UTBETALING_ARBEIDSTAKER -> "omsorgspenger-utbetaling-arbeidstaker-soknad$språkSuffix"
+            Ytelse.OMSORGSPENGER_UTBETALING_SNF -> "omsorgspenger-utbetaling-snf-soknad$språkSuffix"
+            Ytelse.ETTERSENDELSE -> "ettersendelse$språkSuffix"
+            Ytelse.UNGDOMSYTELSE -> "ungdomsytelse-soknad$språkSuffix"
+        }
     }
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/pdf/EttersendelsePdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/pdf/EttersendelsePdfData.kt
@@ -8,9 +8,12 @@ import no.nav.brukerdialog.meldinger.ettersendelse.domene.Pleietrengende
 import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
+import no.nav.k9.søknad.felles.type.Språk
 
 class EttersendelsePdfData(private val ettersendelse: Ettersendelse) : PdfData() {
     override fun ytelse(): Ytelse = Ytelse.ETTERSENDELSE
+
+    override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> = mapOf(
         "tittel" to ettersendelse.søknadstype.tittel,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/pdf/OMPUtbetalingATSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/pdf/OMPUtbetalingATSoknadPDFData.kt
@@ -24,13 +24,8 @@ class OMPUtbetalingATSoknadPDFData(private val melding: OMPUtbetalingATSoknadMot
 
     override fun pdfData(): Map<String, Any?> {
         val mottatt = melding.mottatt.toLocalDate()
-        val tittel = when (språk()) {
-            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
-            else -> ytelse().tittel
-        }
-
         return mapOf(
-            "tittel" to tittel,
+            "tittel" to ytelse().utledTittel(språk()),
             "søknad" to melding.somMap(),
             "språk" to melding.språk.språkTilTekst(),
             "mottaksUkedag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/pdf/OMPUtbetalingATSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/pdf/OMPUtbetalingATSoknadPDFData.kt
@@ -8,6 +8,7 @@ import no.nav.brukerdialog.meldinger.omsorgpengerutbetalingat.domene.*
 import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
+import no.nav.k9.søknad.felles.type.Språk
 import java.time.Duration
 
 class OMPUtbetalingATSoknadPDFData(private val melding: OMPUtbetalingATSoknadMottatt) : PdfData() {
@@ -18,6 +19,8 @@ class OMPUtbetalingATSoknadPDFData(private val melding: OMPUtbetalingATSoknadMot
     }
 
     override fun ytelse(): Ytelse = Ytelse.OMSORGSPENGER_UTBETALING_ARBEIDSTAKER
+
+    override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> {
         val mottatt = melding.mottatt.toLocalDate()

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/pdf/OMPUtbetalingATSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/pdf/OMPUtbetalingATSoknadPDFData.kt
@@ -24,8 +24,13 @@ class OMPUtbetalingATSoknadPDFData(private val melding: OMPUtbetalingATSoknadMot
 
     override fun pdfData(): Map<String, Any?> {
         val mottatt = melding.mottatt.toLocalDate()
+        val tittel = when (språk()) {
+            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
+            else -> ytelse().tittel
+        }
+
         return mapOf(
-            "tittel" to ytelse().tittel,
+            "tittel" to tittel,
             "søknad" to melding.somMap(),
             "språk" to melding.språk.språkTilTekst(),
             "mottaksUkedag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/pdf/OMPUtbetalingSNFSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/pdf/OMPUtbetalingSNFSoknadPDFData.kt
@@ -32,8 +32,13 @@ class OMPUtbetalingSNFSoknadPDFData(private val melding: OMPUtbetalingSNFSoknadM
 
     override fun pdfData(): Map<String, Any?> {
         val mottatt = melding.mottatt.toLocalDate()
+        val tittel = when (språk()) {
+            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
+            else -> ytelse().tittel
+        }
+
         return mapOf(
-            "tittel" to ytelse().tittel,
+            "tittel" to tittel,
             "søknad" to melding.somMap(),
             "språk" to melding.språk.språkTilTekst(),
             "mottaksUkedag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/pdf/OMPUtbetalingSNFSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/pdf/OMPUtbetalingSNFSoknadPDFData.kt
@@ -16,6 +16,7 @@ import no.nav.brukerdialog.meldinger.omsorgpengerutbetalingsnf.domene.Yrkesaktiv
 import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
+import no.nav.k9.søknad.felles.type.Språk
 import java.time.Duration
 
 class OMPUtbetalingSNFSoknadPDFData(private val melding: OMPUtbetalingSNFSoknadMottatt) : PdfData() {
@@ -26,6 +27,8 @@ class OMPUtbetalingSNFSoknadPDFData(private val melding: OMPUtbetalingSNFSoknadM
     }
 
     override fun ytelse(): Ytelse = Ytelse.OMSORGSPENGER_UTBETALING_SNF
+
+    override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> {
         val mottatt = melding.mottatt.toLocalDate()

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/pdf/OMPUtbetalingSNFSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/pdf/OMPUtbetalingSNFSoknadPDFData.kt
@@ -32,13 +32,8 @@ class OMPUtbetalingSNFSoknadPDFData(private val melding: OMPUtbetalingSNFSoknadM
 
     override fun pdfData(): Map<String, Any?> {
         val mottatt = melding.mottatt.toLocalDate()
-        val tittel = when (språk()) {
-            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
-            else -> ytelse().tittel
-        }
-
         return mapOf(
-            "tittel" to tittel,
+            "tittel" to ytelse().utledTittel(språk()),
             "søknad" to melding.somMap(),
             "språk" to melding.språk.språkTilTekst(),
             "mottaksUkedag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/pdf/OMPAleneomsorgSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/pdf/OMPAleneomsorgSoknadPDFData.kt
@@ -8,9 +8,12 @@ import no.nav.brukerdialog.meldinger.omsorgspengeraleneomsorg.domene.somMapTilPd
 import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
+import no.nav.k9.søknad.felles.type.Språk
 
 class OMPAleneomsorgSoknadPDFData(private val melding: OMPAleneomsorgSoknadMottatt): PdfData() {
     override fun ytelse() = Ytelse.OMSORGSDAGER_ALENEOMSORG
+
+    override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> =  mapOf(
         "tittel" to ytelse().tittel,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/pdf/OMPAleneomsorgSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/pdf/OMPAleneomsorgSoknadPDFData.kt
@@ -15,19 +15,25 @@ class OMPAleneomsorgSoknadPDFData(private val melding: OMPAleneomsorgSoknadMotta
 
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
-    override fun pdfData(): Map<String, Any?> =  mapOf(
-        "tittel" to ytelse().tittel,
-        "søknadId" to melding.søknadId,
-        "søknadMottattDag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
-        "søknadMottatt" to DATE_TIME_FORMATTER.format(melding.mottatt),
-        "søker" to melding.søker.somMap(),
-        "barn" to melding.barn.somMapTilPdf(),
-        "samtykke" to mapOf(
-            "harForståttRettigheterOgPlikter" to melding.harForståttRettigheterOgPlikter,
-            "harBekreftetOpplysninger" to melding.harBekreftetOpplysninger
-        ),
-        "hjelp" to mapOf(
-            "språk" to melding.språk?.språkTilTekst()
+    override fun pdfData(): Map<String, Any?> {
+        val tittel = when (språk()) {
+            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
+            else -> ytelse().tittel
+        }
+        return mapOf(
+            "tittel" to tittel,
+            "søknadId" to melding.søknadId,
+            "søknadMottattDag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
+            "søknadMottatt" to DATE_TIME_FORMATTER.format(melding.mottatt),
+            "søker" to melding.søker.somMap(),
+            "barn" to melding.barn.somMapTilPdf(),
+            "samtykke" to mapOf(
+                "harForståttRettigheterOgPlikter" to melding.harForståttRettigheterOgPlikter,
+                "harBekreftetOpplysninger" to melding.harBekreftetOpplysninger
+            ),
+            "hjelp" to mapOf(
+                "språk" to melding.språk?.språkTilTekst()
+            )
         )
-    )
+    }
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/pdf/OMPAleneomsorgSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/pdf/OMPAleneomsorgSoknadPDFData.kt
@@ -16,12 +16,8 @@ class OMPAleneomsorgSoknadPDFData(private val melding: OMPAleneomsorgSoknadMotta
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> {
-        val tittel = when (språk()) {
-            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
-            else -> ytelse().tittel
-        }
         return mapOf(
-            "tittel" to tittel,
+            "tittel" to ytelse().utledTittel(språk()),
             "søknadId" to melding.søknadId,
             "søknadMottattDag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
             "søknadMottatt" to DATE_TIME_FORMATTER.format(melding.mottatt),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerKroniskSyktBarnSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerKroniskSyktBarnSøknad.kt
@@ -21,6 +21,7 @@ import no.nav.brukerdialog.integrasjon.k9mellomlagring.dokumentId
 import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.oppslag.soker.Søker
 import no.nav.brukerdialog.utils.StringUtils.FritekstPattern
+import no.nav.k9.søknad.felles.type.Språk
 import java.net.URL
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
@@ -68,6 +69,7 @@ data class OmsorgspengerKroniskSyktBarnSøknad(
             k9FormatVersjon,
             mottatt,
             søker.somK9Søker(),
+            Språk.of(språk),
             OmsorgspengerKroniskSyktBarn(
                 barn.somK9Barn(),
                 kroniskEllerFunksjonshemming

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
@@ -17,32 +17,37 @@ class OMPUTVKroniskSyktBarnSøknadPdfData(private val søknad: OMPUTVKroniskSykt
         return søknad.k9FormatSøknad.språk
     }
 
-    override fun pdfData(): Map<String, Any?> = mapOf(
-        "tittel" to ytelse().tittel,
-        "tittelNynorsk" to ytelse().nynorskTittel,
-        "soknad_id" to søknad.søknadId,
-        "soknad_mottatt_dag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
-        "soknad_mottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
-        "søker" to søknad.søker.somMap(),
-        "barn" to mapOf(
-            "navn" to søknad.barn.navn.storForbokstav(),
-            "id" to søknad.barn.norskIdentifikator,
-            "fødselsdato" to søknad.barn.fødselsdato
-        ),
-        "relasjonTilBarnet" to søknad.relasjonTilBarnet?.utskriftsvennlig,
-        "sammeAddresse" to søknad.sammeAdresse?.name,
-        "høyereRisikoForFravær" to søknad.høyereRisikoForFravær,
-        "høyereRisikoForFraværBeskrivelse" to søknad.høyereRisikoForFraværBeskrivelse,
-        "kroniskEllerFunksjonshemming" to søknad.kroniskEllerFunksjonshemming,
-        "samtykke" to mapOf(
-            "harForståttRettigheterOgPlikter" to søknad.harForståttRettigheterOgPlikter,
-            "harBekreftetOpplysninger" to søknad.harBekreftetOpplysninger
-        ),
-        "hjelp" to mapOf(
-            "språk" to søknad.språk?.språkTilTekst()
-        ),
-        "harIkkeLastetOppLegeerklæring" to søknad.harIkkeLastetOppLegeerklæring()
-    )
+    override fun pdfData(): Map<String, Any?> = {
+        val tittel = when (språk()) {
+            "nn" -> ytelse().tittelNynorsk
+            else -> ytelse().tittel
+        }
+        return mapOf(
+            "tittel" to tittel,
+            "soknad_id" to søknad.søknadId,
+            "soknad_mottatt_dag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
+            "soknad_mottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
+            "søker" to søknad.søker.somMap(),
+            "barn" to mapOf(
+                "navn" to søknad.barn.navn.storForbokstav(),
+                "id" to søknad.barn.norskIdentifikator,
+                "fødselsdato" to søknad.barn.fødselsdato
+            ),
+            "relasjonTilBarnet" to søknad.relasjonTilBarnet?.utskriftsvennlig,
+            "sammeAddresse" to søknad.sammeAdresse?.name,
+            "høyereRisikoForFravær" to søknad.høyereRisikoForFravær,
+            "høyereRisikoForFraværBeskrivelse" to søknad.høyereRisikoForFraværBeskrivelse,
+            "kroniskEllerFunksjonshemming" to søknad.kroniskEllerFunksjonshemming,
+            "samtykke" to mapOf(
+                "harForståttRettigheterOgPlikter" to søknad.harForståttRettigheterOgPlikter,
+                "harBekreftetOpplysninger" to søknad.harBekreftetOpplysninger
+            ),
+            "hjelp" to mapOf(
+                "språk" to søknad.språk?.språkTilTekst()
+            ),
+            "harIkkeLastetOppLegeerklæring" to søknad.harIkkeLastetOppLegeerklæring()
+        );
+    }
 
     private fun OMPUTVKroniskSyktBarnSøknadMottatt.harIkkeLastetOppLegeerklæring(): Boolean =
         !legeerklæringVedleggId.isNotEmpty()

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
@@ -18,12 +18,8 @@ class OMPUTVKroniskSyktBarnSøknadPdfData(private val søknad: OMPUTVKroniskSykt
     }
 
     override fun pdfData(): Map<String, Any?> {
-        val tittel = when (språk()) {
-            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
-            else -> ytelse().tittel
-        }
         return mapOf(
-            "tittel" to tittel,
+            "tittel" to ytelse().utledTittel(språk()),
             "soknad_id" to søknad.søknadId,
             "soknad_mottatt_dag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
             "soknad_mottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
@@ -17,9 +17,9 @@ class OMPUTVKroniskSyktBarnSøknadPdfData(private val søknad: OMPUTVKroniskSykt
         return søknad.k9FormatSøknad.språk
     }
 
-    override fun pdfData(): Map<String, Any?> = {
+    override fun pdfData(): Map<String, Any?> {
         val tittel = when (språk()) {
-            "nn" -> ytelse().nynorskTittel
+            "nn" -> ytelse().tittelNynorsk
             else -> ytelse().tittel
         }
         return mapOf(
@@ -46,10 +46,10 @@ class OMPUTVKroniskSyktBarnSøknadPdfData(private val søknad: OMPUTVKroniskSykt
                 "språk" to søknad.språk?.språkTilTekst()
             ),
             "harIkkeLastetOppLegeerklæring" to søknad.harIkkeLastetOppLegeerklæring()
-        );
+        )
     }
 
     private fun OMPUTVKroniskSyktBarnSøknadMottatt.harIkkeLastetOppLegeerklæring(): Boolean =
         !legeerklæringVedleggId.isNotEmpty()
-
+        
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
@@ -19,6 +19,7 @@ class OMPUTVKroniskSyktBarnSøknadPdfData(private val søknad: OMPUTVKroniskSykt
 
     override fun pdfData(): Map<String, Any?> = mapOf(
         "tittel" to ytelse().tittel,
+        "tittelNynorsk" to ytelse().nynorskTittel,
         "soknad_id" to søknad.søknadId,
         "soknad_mottatt_dag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
         "soknad_mottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
@@ -18,8 +18,8 @@ class OMPUTVKroniskSyktBarnSøknadPdfData(private val søknad: OMPUTVKroniskSykt
     }
 
     override fun pdfData(): Map<String, Any?> {
-        val tittel = when (språk().getKode()) {
-            "nn" -> ytelse().tittelNynorsk
+        val tittel = when (språk()) {
+            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
             else -> ytelse().tittel
         }
         return mapOf(

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
@@ -8,9 +8,14 @@ import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
 import no.nav.brukerdialog.utils.StringUtils.storForbokstav
+import no.nav.k9.søknad.felles.type.Språk
 
 class OMPUTVKroniskSyktBarnSøknadPdfData(private val søknad: OMPUTVKroniskSyktBarnSøknadMottatt) : PdfData() {
     override fun ytelse(): Ytelse = Ytelse.OMSORGSPENGER_UTVIDET_RETT
+
+    override fun språk(): Språk {
+        return søknad.k9FormatSøknad.språk
+    }
 
     override fun pdfData(): Map<String, Any?> = mapOf(
         "tittel" to ytelse().tittel,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
@@ -18,7 +18,7 @@ class OMPUTVKroniskSyktBarnSøknadPdfData(private val søknad: OMPUTVKroniskSykt
     }
 
     override fun pdfData(): Map<String, Any?> {
-        val tittel = when (språk()) {
+        val tittel = when (språk().getKode()) {
             "nn" -> ytelse().tittelNynorsk
             else -> ytelse().tittel
         }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfData.kt
@@ -19,7 +19,7 @@ class OMPUTVKroniskSyktBarnSøknadPdfData(private val søknad: OMPUTVKroniskSykt
 
     override fun pdfData(): Map<String, Any?> = {
         val tittel = when (språk()) {
-            "nn" -> ytelse().tittelNynorsk
+            "nn" -> ytelse().nynorskTittel
             else -> ytelse().tittel
         }
         return mapOf(

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/pdf/OMPMidlertidigAleneSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/pdf/OMPMidlertidigAleneSoknadPDFData.kt
@@ -8,10 +8,13 @@ import no.nav.brukerdialog.meldinger.omsorgspengermidlertidigalene.domene.somMap
 import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
+import no.nav.k9.søknad.felles.type.Språk
 import java.time.temporal.ChronoUnit
 
 class OMPMidlertidigAleneSoknadPDFData(private val melding: OMPMidlertidigAleneSoknadMottatt): PdfData() {
     override fun ytelse() = Ytelse.OMSORGSPENGER_MIDLERTIDIG_ALENE
+
+    override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> = mapOf(
         "tittel" to ytelse().tittel,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/pdf/OMPMidlertidigAleneSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/pdf/OMPMidlertidigAleneSoknadPDFData.kt
@@ -17,13 +17,8 @@ class OMPMidlertidigAleneSoknadPDFData(private val melding: OMPMidlertidigAleneS
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> {
-        val tittel = when (språk()) {
-            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
-            else -> ytelse().tittel
-        }
-
         return mapOf(
-            "tittel" to tittel,
+            "tittel" to ytelse().utledTittel(språk()),
             "søknadId" to melding.søknadId,
             "søknadMottattDag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
             "søknadMottatt" to DATE_TIME_FORMATTER.format(melding.mottatt),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/pdf/OMPMidlertidigAleneSoknadPDFData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/pdf/OMPMidlertidigAleneSoknadPDFData.kt
@@ -16,24 +16,31 @@ class OMPMidlertidigAleneSoknadPDFData(private val melding: OMPMidlertidigAleneS
 
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
-    override fun pdfData(): Map<String, Any?> = mapOf(
-        "tittel" to ytelse().tittel,
-        "søknadId" to melding.søknadId,
-        "søknadMottattDag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
-        "søknadMottatt" to DATE_TIME_FORMATTER.format(melding.mottatt),
-        "søker" to melding.søker.somMap(),
-        "barn" to melding.barn.somMapTilPdf(),
-        "annenForelder" to melding.annenForelder.somMapTilPdf(),
-        "samtykke" to mapOf(
-            "harForståttRettigheterOgPlikter" to melding.harForståttRettigheterOgPlikter,
-            "harBekreftetOpplysninger" to melding.harBekreftetOpplysninger
-        ),
-        "hjelp" to mapOf(
-            "språk" to melding.språk?.språkTilTekst(),
-            "periodeOver6MånederSatt" to melding.annenForelder.periodeOver6Måneder.erSatt(),
-            "erPeriodenOver6Måneder" to melding.erPeriodeOver6Mnd()
+    override fun pdfData(): Map<String, Any?> {
+        val tittel = when (språk()) {
+            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
+            else -> ytelse().tittel
+        }
+
+        return mapOf(
+            "tittel" to tittel,
+            "søknadId" to melding.søknadId,
+            "søknadMottattDag" to melding.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
+            "søknadMottatt" to DATE_TIME_FORMATTER.format(melding.mottatt),
+            "søker" to melding.søker.somMap(),
+            "barn" to melding.barn.somMapTilPdf(),
+            "annenForelder" to melding.annenForelder.somMapTilPdf(),
+            "samtykke" to mapOf(
+                "harForståttRettigheterOgPlikter" to melding.harForståttRettigheterOgPlikter,
+                "harBekreftetOpplysninger" to melding.harBekreftetOpplysninger
+            ),
+            "hjelp" to mapOf(
+                "språk" to melding.språk?.språkTilTekst(),
+                "periodeOver6MånederSatt" to melding.annenForelder.periodeOver6Måneder.erSatt(),
+                "erPeriodenOver6Måneder" to melding.erPeriodeOver6Mnd()
+            )
         )
-    )
+    }
 
     private fun Boolean?.erSatt() = this != null
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/pdf/PilsSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/pdf/PilsSøknadPdfData.kt
@@ -45,13 +45,8 @@ class PilsSøknadPdfData(private val søknad: PilsSøknadMottatt) : PdfData() {
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> {
-        val tittel = when (språk()) {
-            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
-            else -> ytelse().tittel
-        }
-
         return mapOf(
-            "tittel" to tittel,
+            "tittel" to ytelse().utledTittel(språk()),
             "søknadId" to søknad.søknadId,
             "søknadMottattDag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
             "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/pdf/PilsSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/pdf/PilsSøknadPdfData.kt
@@ -44,50 +44,57 @@ class PilsSøknadPdfData(private val søknad: PilsSøknadMottatt) : PdfData() {
 
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
-    override fun pdfData(): Map<String, Any?> = mapOf(
-        "tittel" to ytelse().tittel,
-        "søknadId" to søknad.søknadId,
-        "søknadMottattDag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
-        "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
-        "periode" to mapOf(
-            "fraOgMed" to DATE_FORMATTER.format(søknad.fraOgMed),
-            "tilOgMed" to DATE_FORMATTER.format(søknad.tilOgMed)
-        ),
-        "dagerMedPleie" to mapOf(
-            "totalAntallDagerMedPleie" to søknad.dagerMedPleie.size,
-            "datoer" to søknad.dagerMedPleie.map { DATE_FORMATTER.format(it) },
-            "uker" to søknad.dagerMedPleie.grupperMedUker().grupperSammenhengendeDatoerPerUke()
-        ),
-        "skalJobbeOgPleieSammeDag" to søknad.skalJobbeOgPleieSammeDag,
-        "pleierDuDenSykeHjemme" to søknad.pleierDuDenSykeHjemme,
-        "søker" to søknad.søker.somMap(),
-        "pleietrengende" to søknad.pleietrengende.somMap(),
-        "medlemskap" to søknad.medlemskap.somMap(),
-        "utenlandsoppholdIPerioden" to mapOf(
-            "skalOppholdeSegIUtlandetIPerioden" to søknad.utenlandsoppholdIPerioden.skalOppholdeSegIUtlandetIPerioden,
-            "opphold" to søknad.utenlandsoppholdIPerioden.opphold.somMapUtenlandsopphold()
-        ),
-        "harLastetOppId" to søknad.opplastetIdVedleggId.isNotEmpty(),
-        "harLastetOppLegeerklæring" to søknad.vedleggId.isNotEmpty(),
-        "arbeidsgivere" to søknad.arbeidsgivere.somMapAnsatt(),
-        "frilans" to søknad.frilans?.somMap(),
-        "selvstendigNæringsdrivende" to søknad.selvstendigNæringsdrivende?.somMap(),
-        "opptjeningIUtlandet" to søknad.opptjeningIUtlandet.somMap(),
-        "utenlandskNæring" to søknad.utenlandskNæring.somMapUtenlandskNæring(),
-        "harVærtEllerErVernepliktig" to søknad.harVærtEllerErVernepliktig,
-        "samtykke" to mapOf(
-            "harForståttRettigheterOgPlikter" to søknad.harForståttRettigheterOgPlikter,
-            "harBekreftetOpplysninger" to søknad.harBekreftetOpplysninger
-        ),
-        "flereSokere" to søknad.flereSokere?.name,
-        "hjelp" to mapOf(
-            "språk" to søknad.språk?.språkTilTekst(),
-            "ingen_arbeidsgivere" to søknad.arbeidsgivere.isEmpty(),
-            "harFlereAktiveVirksomheterErSatt" to søknad.harFlereAktiveVirksomehterSatt(),
-            "ingen_arbeidsforhold" to !søknad.harMinstEtArbeidsforhold(),
-            "harVærtEllerErVernepliktigErSatt" to (søknad.harVærtEllerErVernepliktig != null)
+    override fun pdfData(): Map<String, Any?> {
+        val tittel = when (språk()) {
+            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
+            else -> ytelse().tittel
+        }
+
+        return mapOf(
+            "tittel" to tittel,
+            "søknadId" to søknad.søknadId,
+            "søknadMottattDag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
+            "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
+            "periode" to mapOf(
+                "fraOgMed" to DATE_FORMATTER.format(søknad.fraOgMed),
+                "tilOgMed" to DATE_FORMATTER.format(søknad.tilOgMed)
+            ),
+            "dagerMedPleie" to mapOf(
+                "totalAntallDagerMedPleie" to søknad.dagerMedPleie.size,
+                "datoer" to søknad.dagerMedPleie.map { DATE_FORMATTER.format(it) },
+                "uker" to søknad.dagerMedPleie.grupperMedUker().grupperSammenhengendeDatoerPerUke()
+            ),
+            "skalJobbeOgPleieSammeDag" to søknad.skalJobbeOgPleieSammeDag,
+            "pleierDuDenSykeHjemme" to søknad.pleierDuDenSykeHjemme,
+            "søker" to søknad.søker.somMap(),
+            "pleietrengende" to søknad.pleietrengende.somMap(),
+            "medlemskap" to søknad.medlemskap.somMap(),
+            "utenlandsoppholdIPerioden" to mapOf(
+                "skalOppholdeSegIUtlandetIPerioden" to søknad.utenlandsoppholdIPerioden.skalOppholdeSegIUtlandetIPerioden,
+                "opphold" to søknad.utenlandsoppholdIPerioden.opphold.somMapUtenlandsopphold()
+            ),
+            "harLastetOppId" to søknad.opplastetIdVedleggId.isNotEmpty(),
+            "harLastetOppLegeerklæring" to søknad.vedleggId.isNotEmpty(),
+            "arbeidsgivere" to søknad.arbeidsgivere.somMapAnsatt(),
+            "frilans" to søknad.frilans?.somMap(),
+            "selvstendigNæringsdrivende" to søknad.selvstendigNæringsdrivende?.somMap(),
+            "opptjeningIUtlandet" to søknad.opptjeningIUtlandet.somMap(),
+            "utenlandskNæring" to søknad.utenlandskNæring.somMapUtenlandskNæring(),
+            "harVærtEllerErVernepliktig" to søknad.harVærtEllerErVernepliktig,
+            "samtykke" to mapOf(
+                "harForståttRettigheterOgPlikter" to søknad.harForståttRettigheterOgPlikter,
+                "harBekreftetOpplysninger" to søknad.harBekreftetOpplysninger
+            ),
+            "flereSokere" to søknad.flereSokere?.name,
+            "hjelp" to mapOf(
+                "språk" to søknad.språk?.språkTilTekst(),
+                "ingen_arbeidsgivere" to søknad.arbeidsgivere.isEmpty(),
+                "harFlereAktiveVirksomheterErSatt" to søknad.harFlereAktiveVirksomehterSatt(),
+                "ingen_arbeidsforhold" to !søknad.harMinstEtArbeidsforhold(),
+                "harVærtEllerErVernepliktigErSatt" to (søknad.harVærtEllerErVernepliktig != null)
+            )
         )
-    )
+    }
 
     private fun Pleietrengende.somMap() = mapOf<String, Any?>(
         "manglerNorskIdentitetsnummer" to (norskIdentitetsnummer == null),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/pdf/PilsSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/pdf/PilsSøknadPdfData.kt
@@ -32,6 +32,7 @@ import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.DateUtils.somNorskMåned
 import no.nav.brukerdialog.utils.DurationUtils.somTekst
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
+import no.nav.k9.søknad.felles.type.Språk
 import java.time.LocalDate
 import java.time.Month
 import java.time.ZoneId
@@ -40,6 +41,8 @@ import java.time.temporal.WeekFields
 
 class PilsSøknadPdfData(private val søknad: PilsSøknadMottatt) : PdfData() {
     override fun ytelse(): Ytelse = Ytelse.PLEIEPENGER_LIVETS_SLUTTFASE
+
+    override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> = mapOf(
         "tittel" to ytelse().tittel,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/pdf/PSBEndringsmeldingPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/pdf/PSBEndringsmeldingPdfData.kt
@@ -18,6 +18,7 @@ import no.nav.brukerdialog.meldinger.endringsmelding.domene.PSBEndringsmeldingMo
 import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.DurationUtils.somTekst
+import no.nav.k9.søknad.felles.type.Språk
 import java.time.DayOfWeek
 import java.time.Duration
 import java.time.ZoneOffset.UTC
@@ -25,6 +26,9 @@ import java.time.temporal.WeekFields
 
 class PSBEndringsmeldingPdfData(private val endringsmelding: PSBEndringsmeldingMottatt) : PdfData() {
     override fun ytelse(): Ytelse = Ytelse.PLEIEPENGER_SYKT_BARN_ENDRINGSMELDING
+
+    override fun språk(): Språk = Språk.NORSK_BOKMÅL
+
     override fun pdfData(): Map<String, Any?> {
 
         val k9Format = endringsmelding.k9Format

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/pdf/PSBEndringsmeldingPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/pdf/PSBEndringsmeldingPdfData.kt
@@ -34,8 +34,13 @@ class PSBEndringsmeldingPdfData(private val endringsmelding: PSBEndringsmeldingM
         val k9Format = endringsmelding.k9Format
         val ytelse = k9Format.getYtelse<PleiepengerSyktBarn>()
         val dataBruktTilUtledning = ytelse.søknadInfo.orElse(null)
+        val tittel = when (språk()) {
+            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
+            else -> ytelse().tittel
+        }
+
         return mapOf(
-            "tittel" to ytelse().tittel,
+            "tittel" to tittel,
             "søknadId" to k9Format.søknadId.id,
             "soknadDialogCommitSha" to dataBruktTilUtledning?.soknadDialogCommitSha,
             "mottattDag" to k9Format.mottattDato.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/pdf/PSBEndringsmeldingPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/pdf/PSBEndringsmeldingPdfData.kt
@@ -34,13 +34,8 @@ class PSBEndringsmeldingPdfData(private val endringsmelding: PSBEndringsmeldingM
         val k9Format = endringsmelding.k9Format
         val ytelse = k9Format.getYtelse<PleiepengerSyktBarn>()
         val dataBruktTilUtledning = ytelse.søknadInfo.orElse(null)
-        val tittel = when (språk()) {
-            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
-            else -> ytelse().tittel
-        }
-
         return mapOf(
-            "tittel" to tittel,
+            "tittel" to ytelse().utledTittel(språk()),
             "søknadId" to k9Format.søknadId.id,
             "soknadDialogCommitSha" to dataBruktTilUtledning?.soknadDialogCommitSha,
             "mottattDag" to k9Format.mottattDato.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/PleiepengerSyktBarnSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/PleiepengerSyktBarnSøknad.kt
@@ -49,7 +49,7 @@ data class PleiepengerSyktBarnSøknad(
         .toString(),
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
-    val språk: Språk? = null,
+    val språk: Språk,
     val søkerNorskIdent: String? = null, // TODO: Fjern nullable når vi har lansert og mellomlagring inneholder dette feltet.
     @field:Valid val barn: BarnDetaljer,
     @field:Valid val arbeidsgivere: List<Arbeidsgiver>,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/domene/PSBMottattSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/domene/PSBMottattSøknad.kt
@@ -28,7 +28,7 @@ data class PSBMottattSøknad(
     val søknadId: String,
     val mottatt: ZonedDateTime,
     val apiDataVersjon: String? = null,
-    val språk: String? = null,
+    val språk: String,
     val fraOgMed : LocalDate,
     val tilOgMed : LocalDate,
     val søker : Søker,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/domene/PSBPreprosessertSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/domene/PSBPreprosessertSøknad.kt
@@ -29,7 +29,7 @@ import java.time.ZonedDateTime
 
 data class PSBPreprosessertSøknad(
     val apiDataVersjon: String? = null,
-    val språk: String?,
+    val språk: String,
     val søknadId: String,
     val dokumentId: List<List<String>>,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfData.kt
@@ -51,60 +51,67 @@ class PSBSøknadPdfData(private val søknad: PSBMottattSøknad) : PdfData() {
 
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
-    override fun pdfData(): Map<String, Any?> = mapOf(
-        "tittel" to ytelse().tittel,
-        "soknad_id" to søknad.søknadId,
-        "soknad_mottatt_dag" to søknad.mottatt.withZoneSameInstant(Constants.OSLO_ZONE_ID).somNorskDag(),
-        "soknad_mottatt" to Constants.DATE_TIME_FORMATTER.format(søknad.mottatt),
-        "harIkkeVedlegg" to søknad.sjekkOmHarIkkeVedlegg(),
-        "harLastetOppFødselsattest" to !søknad.fødselsattestVedleggId.isNullOrEmpty(),
-        "soker" to søknad.søker.somMap(),
-        "barn" to søknad.barn.somMap(),
-        "periode" to mapOf(
-            "fra_og_med" to Constants.DATE_FORMATTER.format(søknad.fraOgMed),
-            "til_og_med" to Constants.DATE_FORMATTER.format(søknad.tilOgMed),
-            "virkedager" to DateUtils.antallVirkedager(søknad.fraOgMed, søknad.tilOgMed)
-        ),
-        "medlemskap" to mapOf(
-            "har_bodd_i_utlandet_siste_12_mnd" to søknad.medlemskap.harBoddIUtlandetSiste12Mnd,
-            "utenlandsopphold_siste_12_mnd" to søknad.medlemskap.utenlandsoppholdSiste12Mnd.somMapBosted(),
-            "skal_bo_i_utlandet_neste_12_mnd" to søknad.medlemskap.skalBoIUtlandetNeste12Mnd,
-            "utenlandsopphold_neste_12_mnd" to søknad.medlemskap.utenlandsoppholdNeste12Mnd.somMapBosted()
-        ),
-        "samtykke" to mapOf(
-            "har_forstatt_rettigheter_og_plikter" to søknad.harForståttRettigheterOgPlikter,
-            "har_bekreftet_opplysninger" to søknad.harBekreftetOpplysninger
-        ),
-        "hjelp" to mapOf(
-            "ingen_arbeidsgivere" to søknad.arbeidsgivere.isEmpty(),
-            "sprak" to søknad.språk?.språkTilTekst()
-        ),
-        "opptjeningIUtlandet" to søknad.opptjeningIUtlandet.somMapOpptjeningIUtlandet(),
-        "utenlandskNæring" to søknad.utenlandskNæring.somMapUtenlandskNæring(),
-        "omsorgstilbud" to søknad.omsorgstilbud?.somMap(),
-        "nattevaak" to nattevåk(søknad.nattevåk),
-        "beredskap" to beredskap(søknad.beredskap),
-        "utenlandsoppholdIPerioden" to mapOf(
-            "skalOppholdeSegIUtlandetIPerioden" to søknad.utenlandsoppholdIPerioden.skalOppholdeSegIUtlandetIPerioden,
-            "opphold" to søknad.utenlandsoppholdIPerioden.opphold.somMapUtenlandsopphold()
-        ),
-        "ferieuttakIPerioden" to mapOf(
-            "skalTaUtFerieIPerioden" to søknad.ferieuttakIPerioden?.skalTaUtFerieIPerioden,
-            "ferieuttak" to søknad.ferieuttakIPerioden?.ferieuttak?.somMapFerieuttak()
-        ),
-        "barnRelasjon" to søknad.barnRelasjon?.utskriftsvennlig,
-        "barnRelasjonBeskrivelse" to søknad.barnRelasjonBeskrivelse,
-        "harVærtEllerErVernepliktig" to søknad.harVærtEllerErVernepliktig,
-        "frilans" to søknad.frilans.somMap(søknad.fraOgMed),
-        "stønadGodtgjørelse" to søknad.stønadGodtgjørelse?.somMap(),
-        "selvstendigNæringsdrivende" to søknad.selvstendigNæringsdrivende.somMap(),
-        "arbeidsgivere" to søknad.arbeidsgivere.somMapAnsatt(),
-        "hjelper" to mapOf(
-            "harFlereAktiveVirksomheterErSatt" to søknad.harFlereAktiveVirksomehterSatt(),
-            "harVærtEllerErVernepliktigErSatt" to erBooleanSatt(søknad.harVærtEllerErVernepliktig),
-            "ingen_arbeidsforhold" to !søknad.harMinstEtArbeidsforhold()
+    override fun pdfData(): Map<String, Any?> {
+        val tittel = when (språk()) {
+            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
+            else -> ytelse().tittel
+        }
+
+        return mapOf(
+            "tittel" to tittel,
+            "soknad_id" to søknad.søknadId,
+            "soknad_mottatt_dag" to søknad.mottatt.withZoneSameInstant(Constants.OSLO_ZONE_ID).somNorskDag(),
+            "soknad_mottatt" to Constants.DATE_TIME_FORMATTER.format(søknad.mottatt),
+            "harIkkeVedlegg" to søknad.sjekkOmHarIkkeVedlegg(),
+            "harLastetOppFødselsattest" to !søknad.fødselsattestVedleggId.isNullOrEmpty(),
+            "soker" to søknad.søker.somMap(),
+            "barn" to søknad.barn.somMap(),
+            "periode" to mapOf(
+                "fra_og_med" to Constants.DATE_FORMATTER.format(søknad.fraOgMed),
+                "til_og_med" to Constants.DATE_FORMATTER.format(søknad.tilOgMed),
+                "virkedager" to DateUtils.antallVirkedager(søknad.fraOgMed, søknad.tilOgMed)
+            ),
+            "medlemskap" to mapOf(
+                "har_bodd_i_utlandet_siste_12_mnd" to søknad.medlemskap.harBoddIUtlandetSiste12Mnd,
+                "utenlandsopphold_siste_12_mnd" to søknad.medlemskap.utenlandsoppholdSiste12Mnd.somMapBosted(),
+                "skal_bo_i_utlandet_neste_12_mnd" to søknad.medlemskap.skalBoIUtlandetNeste12Mnd,
+                "utenlandsopphold_neste_12_mnd" to søknad.medlemskap.utenlandsoppholdNeste12Mnd.somMapBosted()
+            ),
+            "samtykke" to mapOf(
+                "har_forstatt_rettigheter_og_plikter" to søknad.harForståttRettigheterOgPlikter,
+                "har_bekreftet_opplysninger" to søknad.harBekreftetOpplysninger
+            ),
+            "hjelp" to mapOf(
+                "ingen_arbeidsgivere" to søknad.arbeidsgivere.isEmpty(),
+                "sprak" to søknad.språk?.språkTilTekst()
+            ),
+            "opptjeningIUtlandet" to søknad.opptjeningIUtlandet.somMapOpptjeningIUtlandet(),
+            "utenlandskNæring" to søknad.utenlandskNæring.somMapUtenlandskNæring(),
+            "omsorgstilbud" to søknad.omsorgstilbud?.somMap(),
+            "nattevaak" to nattevåk(søknad.nattevåk),
+            "beredskap" to beredskap(søknad.beredskap),
+            "utenlandsoppholdIPerioden" to mapOf(
+                "skalOppholdeSegIUtlandetIPerioden" to søknad.utenlandsoppholdIPerioden.skalOppholdeSegIUtlandetIPerioden,
+                "opphold" to søknad.utenlandsoppholdIPerioden.opphold.somMapUtenlandsopphold()
+            ),
+            "ferieuttakIPerioden" to mapOf(
+                "skalTaUtFerieIPerioden" to søknad.ferieuttakIPerioden?.skalTaUtFerieIPerioden,
+                "ferieuttak" to søknad.ferieuttakIPerioden?.ferieuttak?.somMapFerieuttak()
+            ),
+            "barnRelasjon" to søknad.barnRelasjon?.utskriftsvennlig,
+            "barnRelasjonBeskrivelse" to søknad.barnRelasjonBeskrivelse,
+            "harVærtEllerErVernepliktig" to søknad.harVærtEllerErVernepliktig,
+            "frilans" to søknad.frilans.somMap(søknad.fraOgMed),
+            "stønadGodtgjørelse" to søknad.stønadGodtgjørelse?.somMap(),
+            "selvstendigNæringsdrivende" to søknad.selvstendigNæringsdrivende.somMap(),
+            "arbeidsgivere" to søknad.arbeidsgivere.somMapAnsatt(),
+            "hjelper" to mapOf(
+                "harFlereAktiveVirksomheterErSatt" to søknad.harFlereAktiveVirksomehterSatt(),
+                "harVærtEllerErVernepliktigErSatt" to erBooleanSatt(søknad.harVærtEllerErVernepliktig),
+                "ingen_arbeidsforhold" to !søknad.harMinstEtArbeidsforhold()
+            )
         )
-    )
+    }
 
     private fun Barn.somMap() = mapOf<String, Any?>(
         "manglerNorskIdentitetsnummer" to (fødselsnummer == null),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfData.kt
@@ -52,13 +52,8 @@ class PSBSøknadPdfData(private val søknad: PSBMottattSøknad) : PdfData() {
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> {
-        val tittel = when (språk()) {
-            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
-            else -> ytelse().tittel
-        }
-
         return mapOf(
-            "tittel" to tittel,
+            "tittel" to ytelse().utledTittel(språk()),
             "soknad_id" to søknad.søknadId,
             "soknad_mottatt_dag" to søknad.mottatt.withZoneSameInstant(Constants.OSLO_ZONE_ID).somNorskDag(),
             "soknad_mottatt" to Constants.DATE_TIME_FORMATTER.format(søknad.mottatt),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfData.kt
@@ -38,6 +38,7 @@ import no.nav.brukerdialog.utils.DurationUtils.somTekst
 import no.nav.brukerdialog.utils.DurationUtils.tilString
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
 import no.nav.brukerdialog.utils.StringUtils.storForbokstav
+import no.nav.k9.søknad.felles.type.Språk
 import java.time.DayOfWeek
 import java.time.Duration
 import java.time.LocalDate
@@ -47,6 +48,9 @@ import java.time.temporal.WeekFields
 
 class PSBSøknadPdfData(private val søknad: PSBMottattSøknad) : PdfData() {
     override fun ytelse(): Ytelse = Ytelse.PLEIEPENGER_SYKT_BARN
+
+    override fun språk(): Språk = Språk.NORSK_BOKMÅL
+
     override fun pdfData(): Map<String, Any?> = mapOf(
         "tittel" to ytelse().tittel,
         "soknad_id" to søknad.søknadId,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/UngdomsytelseKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/UngdomsytelseKomplettSøknad.kt
@@ -11,7 +11,7 @@ class UngdomsytelseKomplettSøknad(
     private val søker: Søker,
     private val språk: String,
     private val fraOgMed: LocalDate,
-    private val tilOgMed: LocalDate,
+    private val tilOgMed: LocalDate? = null,
     private val mottatt: ZonedDateTime,
     private val harForståttRettigheterOgPlikter: Boolean,
     private val harBekreftetOpplysninger: Boolean,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/Ungdomsytelsesøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/Ungdomsytelsesøknad.kt
@@ -26,7 +26,7 @@ data class Ungdomsytelsesøknad(
     val språk: String,
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
     val fraOgMed: LocalDate,
-    val tilOgMed: LocalDate,
+    val tilOgMed: LocalDate? = null,
 
     val søkerNorskIdent: String,
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/domene/UngdomsytelsesøknadMottatt.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/domene/UngdomsytelsesøknadMottatt.kt
@@ -16,7 +16,7 @@ data class UngdomsytelsesøknadMottatt(
     val språk: String? = "nb",
     val søker: Søker,
     val fraOgMed: LocalDate,
-    val tilOgMed: LocalDate,
+    val tilOgMed: LocalDate ?= null,
     val k9Format: Søknad,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/domene/UngdomsytelsesøknadPreprosessertSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/domene/UngdomsytelsesøknadPreprosessertSøknad.kt
@@ -20,7 +20,7 @@ data class UngdomsytelsesøknadPreprosessertSøknad(
     val språk: String?,
     val søker: Søker,
     val fraOgMed: LocalDate,
-    val tilOgMed: LocalDate,
+    val tilOgMed: LocalDate? = null,
     val dokumentId: List<List<String>>,
     val k9Format: K9Søknad,
     val harForståttRettigheterOgPlikter: Boolean,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
@@ -19,7 +19,7 @@ class UngdomsytelsesøknadPdfData(private val søknad: UngdomsytelsesøknadMotta
         "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
         "periode" to mapOf(
             "fraOgMed" to DATE_FORMATTER.format(søknad.fraOgMed),
-            "tilOgMed" to DATE_FORMATTER.format(søknad.tilOgMed)
+            "tilOgMed" to søknad.tilOgMed?.let { DATE_FORMATTER.format(it) }
         ),
         "søker" to søknad.søker.somMap(),
         "samtykke" to mapOf(

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
@@ -16,13 +16,8 @@ class UngdomsytelsesøknadPdfData(private val søknad: UngdomsytelsesøknadMotta
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> {
-        val tittel = when (språk()) {
-            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
-            else -> ytelse().tittel
-        }
-
         return mapOf(
-            "tittel" to tittel,
+            "tittel" to ytelse().utledTittel(språk()),
             "søknadId" to søknad.søknadId,
             "søknadMottattDag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
             "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
@@ -8,9 +8,12 @@ import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.domene.UngdomsytelsesøknadMottatt
+import no.nav.k9.søknad.felles.type.Språk
 
 class UngdomsytelsesøknadPdfData(private val søknad: UngdomsytelsesøknadMottatt) : PdfData() {
     override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE
+
+    override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
     override fun pdfData(): Map<String, Any?> = mapOf(
         "tittel" to ytelse().tittel,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
@@ -15,22 +15,29 @@ class UngdomsytelsesøknadPdfData(private val søknad: UngdomsytelsesøknadMotta
 
     override fun språk(): Språk = Språk.NORSK_BOKMÅL
 
-    override fun pdfData(): Map<String, Any?> = mapOf(
-        "tittel" to ytelse().tittel,
-        "søknadId" to søknad.søknadId,
-        "søknadMottattDag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
-        "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
-        "periode" to mapOf(
-            "fraOgMed" to DATE_FORMATTER.format(søknad.fraOgMed),
-            "tilOgMed" to søknad.tilOgMed?.let { DATE_FORMATTER.format(it) }
-        ),
-        "søker" to søknad.søker.somMap(),
-        "samtykke" to mapOf(
-            "harForståttRettigheterOgPlikter" to søknad.harForståttRettigheterOgPlikter,
-            "harBekreftetOpplysninger" to søknad.harBekreftetOpplysninger
-        ),
-        "hjelp" to mapOf(
-            "språk" to søknad.språk?.språkTilTekst()
+    override fun pdfData(): Map<String, Any?> {
+        val tittel = when (språk()) {
+            Språk.NORSK_NYNORSK -> ytelse().nynorskTittel
+            else -> ytelse().tittel
+        }
+
+        return mapOf(
+            "tittel" to tittel,
+            "søknadId" to søknad.søknadId,
+            "søknadMottattDag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
+            "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
+            "periode" to mapOf(
+                "fraOgMed" to DATE_FORMATTER.format(søknad.fraOgMed),
+                "tilOgMed" to søknad.tilOgMed?.let { DATE_FORMATTER.format(it) }
+            ),
+            "søker" to søknad.søker.somMap(),
+            "samtykke" to mapOf(
+                "harForståttRettigheterOgPlikter" to søknad.harForståttRettigheterOgPlikter,
+                "harBekreftetOpplysninger" to søknad.harBekreftetOpplysninger
+            ),
+            "hjelp" to mapOf(
+                "språk" to søknad.språk?.språkTilTekst()
+            )
         )
-    )
+    }
 }

--- a/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
+++ b/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
@@ -75,7 +75,7 @@
         {{/if}}
     </section>
 
-    <!-- SAMTYKKE -->
+    <!-- Samtykke -->
     <section id="samtykke">
         <h2>Samtykke frå deg</h2>
         <p class="sporsmalstekst">Har du forstått rettigheter og plikter?</p>

--- a/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
+++ b/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
@@ -3,10 +3,10 @@
 
 <head>
     <meta charset="UTF-8"/>
-    <title>{{nynorskTittel}}</title>
-    <meta name="subject" content="{{nynorskTittel}}"/>
+    <title>{{tittel}}</title>
+    <meta name="subject" content="{{tittel}}"/>
     <meta name="author" content="nav.no"/>
-    <meta name="description" content="{{nynorskTittel}} mottatt {{soknad_mottatt_dag}} {{ soknad_mottatt }}"/>
+    <meta name="description" content="{{tittel}} mottatt {{soknad_mottatt_dag}} {{ soknad_mottatt }}"/>
     <bookmarks>
         <bookmark name="Søker" href="#søker"/>
         <bookmark name="Barn" href="#barn"/>
@@ -21,7 +21,7 @@
 </head>
 
 <body>
-<h1 id="header">{{nynorskTittel}}</h1>
+<h1 id="header">{{tittel}}</h1>
 <p class="nokkelinfo">
     <strong>Sendt til NAV</strong>
     {{soknad_mottatt_dag}} {{ soknad_mottatt }}

--- a/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
+++ b/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
@@ -3,10 +3,10 @@
 
 <head>
     <meta charset="UTF-8"/>
-    <title>{{tittel}}</title>
-    <meta name="subject" content="{{tittel}}"/>
+    <title>{{nynorskTittel}}</title>
+    <meta name="subject" content="{{nynorskTittel}}"/>
     <meta name="author" content="nav.no"/>
-    <meta name="description" content="{{tittel}} mottatt {{soknad_mottatt_dag}} {{ soknad_mottatt }}"/>
+    <meta name="description" content="{{nynorskTittel}} mottatt {{soknad_mottatt_dag}} {{ soknad_mottatt }}"/>
     <bookmarks>
         <bookmark name="Søker" href="#søker"/>
         <bookmark name="Barn" href="#barn"/>
@@ -21,7 +21,7 @@
 </head>
 
 <body>
-<h1 id="header">{{tittel}}</h1>
+<h1 id="header">{{nynorskTittel}}</h1>
 <p class="nokkelinfo">
     <strong>Sendt til NAV</strong>
     {{soknad_mottatt_dag}} {{ soknad_mottatt }}

--- a/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
+++ b/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
@@ -45,11 +45,11 @@
             <p>Nei</p>
         {{/eq}}
 
-        <p class="sporsmalstekst">Har barnet kronisk/langvarig sjukdom eller funksjonshemning?</p>
+        <p class="sporsmalstekst">Har barnet kronisk/langvarig sjukdom eller funksjonshemming?</p>
         <p>{{ jaNeiSvar kroniskEllerFunksjonshemming }}</p>
 
         {{#if kroniskEllerFunksjonshemming}}
-            <p class="sporsmalstekst">Har du høgare risiko for fråvær på jobb på grunn av sjukdommen eller funksjonshemninga til barnet?</p>
+            <p class="sporsmalstekst">Har du høgare risiko for fråvær på jobb på grunn av sjukdommen eller funksjonshemminga til barnet?</p>
             <p>{{ jaNeiSvar høyereRisikoForFravær }}</p>
 
             {{#if høyereRisikoForFravær}}

--- a/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
+++ b/src/main/resources/handlebars/omsorgspenger-utvidet-rett-kronisk-sykt-barn-soknad.nn.hbs
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="NO">
+
+<head>
+    <meta charset="UTF-8"/>
+    <title>{{tittel}}</title>
+    <meta name="subject" content="{{tittel}}"/>
+    <meta name="author" content="nav.no"/>
+    <meta name="description" content="{{tittel}} mottatt {{soknad_mottatt_dag}} {{ soknad_mottatt }}"/>
+    <bookmarks>
+        <bookmark name="Søker" href="#søker"/>
+        <bookmark name="Barn" href="#barn"/>
+        <bookmark name="Om barnet" href="#omBarnet"/>
+        {{#if harIkkeLastetOppLegeerklæring}}
+            <bookmark name="Legeerklæring" href="#legeerklæring"/>
+        {{/if}}
+        <bookmark name="Samtykke" href="#samtykke"/>
+    </bookmarks>
+    {{#block 'style-common' }}
+    {{/block}}
+</head>
+
+<body>
+<h1 id="header">{{tittel}}</h1>
+<p class="nokkelinfo">
+    <strong>Sendt til NAV</strong>
+    {{soknad_mottatt_dag}} {{ soknad_mottatt }}
+</p>
+
+<div class="innholdscontainer">
+    {{> partial/felles/personPartial.nn id="søker" title="Søker" navn=søker.navn fødselsnummer=søker.fødselsnummer }}
+    {{> partial/felles/personPartial.nn id="barn" title="Barn" navn=barn.navn fødselsdato=barn.fødselsdato fødselsnummer=barn.id }}
+
+    <section id="omBarnet">
+        <h2>Om barnet</h2>
+
+        <p class="sporsmalstekst">Bur du saman med barnet?</p>
+        {{#eq sammeAddresse "JA" }}
+            <p>Ja</p>
+        {{/eq}}
+        {{#eq sammeAddresse "JA_DELT_BOSTED" }}
+            <p>Ja, barnet har delt bustad</p>
+        {{/eq}}
+        {{#eq sammeAddresse "NEI" }}
+            <p>Nei</p>
+        {{/eq}}
+
+        <p class="sporsmalstekst">Har barnet kronisk/langvarig sjukdom eller funksjonshemning?</p>
+        <p>{{ jaNeiSvar kroniskEllerFunksjonshemming }}</p>
+
+        {{#if kroniskEllerFunksjonshemming}}
+            <p class="sporsmalstekst">Har du høgare risiko for fråvær på jobb på grunn av sjukdommen eller funksjonshemninga til barnet?</p>
+            <p>{{ jaNeiSvar høyereRisikoForFravær }}</p>
+
+            {{#if høyereRisikoForFravær}}
+                <div class="fritekst">
+                    <p class="sporsmalstekst">Skildring av korleis barnet sin sjukdom eller funksjonshemming gjer det meir sannsynleg at du må vera borte frå jobb.</p>
+                    <p class="fritekst_textarea">{{fritekst høyereRisikoForFraværBeskrivelse}}</p>
+                </div>
+            {{/if}}
+        {{/if}}
+
+        {{#if relasjonTilBarnet}}
+            <p class="sporsmalstekst">Din relasjon til barnet:</p>
+            <p>{{relasjonTilBarnet}}</p>
+        {{/if}}
+
+    </section>
+
+    <!-- Info om har ikke lastet opp vedlegg -->
+    <section id="legeerklæring">
+        {{#if harIkkeLastetOppLegeerklæring}}
+            <h2>Legeerklæring</h2>
+            <p>Ingen vedlegg er lasta opp.</p>
+        {{/if}}
+    </section>
+
+    <!-- SAMTYKKE -->
+    <section id="samtykke">
+        <h2>Samtykke frå deg</h2>
+        <p class="sporsmalstekst">Har du forstått rettigheter og plikter?</p>
+        <p>{{ jaNeiSvar samtykke.harForståttRettigheterOgPlikter }}</p>
+        <hr/>
+        <p class="sporsmalstekst">Har du stadfesta at opplysningar som er gitt er rette?</p>
+        <p>{{ jaNeiSvar samtykke.harBekreftetOpplysninger }}</p>
+    </section>
+</div>
+
+<!-- FOOTER -->
+{{> partial/footerPartial søknadId=soknad_id gitSha=soknadDialogCommitSha}}
+</body>
+
+</html>

--- a/src/main/resources/handlebars/partial/felles/personPartial.nn.hbs
+++ b/src/main/resources/handlebars/partial/felles/personPartial.nn.hbs
@@ -1,0 +1,25 @@
+<div class="person" id="{{ id }}">
+    <p>{{ title }}</p>
+    <p class="navn">
+        {{# if navn }}
+            {{ navn }}
+        {{else}}
+            <span class="ikke_satt">Namn ikkje angitt</span>
+        {{/if}}
+    </p>
+    {{# if fødselsnummer }}
+        <p>{{ fødselsnummer }}</p>
+    {{/if}}
+    {{#if fødselsdato}}
+        <p>Fødselsdato: {{fødselsdato}}</p>
+    {{/if}}
+    {{#if årsakManglerIdentitetsnummer}}
+        {{#eq id "pleietrengende"}}
+            <p>Oppgitt grunn for at pleietrengande ikkje har fødselsnummer/D-nummer: {{årsakManglerIdentitetsnummer}}</p>
+        {{/eq}}
+        {{#eq id "barn"}}
+            <p>Oppgitt grunn for at barnet ikkje har fødselsnummer/D-nummer: {{årsakManglerIdentitetsnummer}}</p>
+        {{/eq}}
+    {{/if}}
+</div>
+

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest.kt
@@ -8,6 +8,7 @@ import no.nav.brukerdialog.meldinger.omsorgspengerkronisksyktbarn.domene.SøkerB
 import no.nav.brukerdialog.ytelse.omsorgspengerkronisksyktbarn.utils.OMPKSSøknadUtils
 import no.nav.brukerdialog.pdf.PDFGenerator
 import no.nav.brukerdialog.utils.PathUtils.pdfPath
+import no.nav.k9.søknad.felles.type.Språk
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.time.LocalDate
@@ -32,6 +33,7 @@ class OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest {
         private fun fullGyldigMelding(
             soknadsId: String,
             legeerklæringVedleggId: List<String> = listOf(),
+            språk: Språk = Språk.NORSK_BOKMÅL
         ) = OMPUTVKroniskSyktBarnSøknadMottatt(
             språk = "nb",
             søknadId = soknadsId,
@@ -58,7 +60,7 @@ class OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest {
             sammeAdresse = BarnSammeAdresse.JA_DELT_BOSTED,
             høyereRisikoForFravær = true,
             høyereRisikoForFraværBeskrivelse = "Beskrivelse av høyere risiko for fravær",
-            k9FormatSøknad = OMPKSSøknadUtils.defaultK9Format(soknadsId, ZonedDateTime.now())
+            k9FormatSøknad = OMPKSSøknadUtils.defaultK9Format(soknadsId, ZonedDateTime.now(), språk)
         )
     }
 
@@ -72,6 +74,12 @@ class OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest {
         id = "2-full-søknad-legeerklæring-lastet-opp"
         pdf = generator.genererPDF(
             pdfData = fullGyldigMelding(soknadsId = id, legeerklæringVedleggId = listOf("123")).pdfData(),
+        )
+        if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+        id = "3-full-søknad-nynorsk"
+        pdf = generator.genererPDF(
+            pdfData = fullGyldigMelding(soknadsId = id, språk = Språk.NORSK_NYNORSK).pdfData(),
         )
         if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
     }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/OMPKSSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/OMPKSSøknadUtils.kt
@@ -10,6 +10,7 @@ import no.nav.brukerdialog.meldinger.omsorgspengerkronisksyktbarn.domene.Barn
 import no.nav.brukerdialog.meldinger.omsorgspengerkronisksyktbarn.domene.BarnSammeAdresse
 import no.nav.brukerdialog.meldinger.omsorgspengerkronisksyktbarn.domene.OMPUTVKroniskSyktBarnSøknadMottatt
 import no.nav.brukerdialog.meldinger.omsorgspengerkronisksyktbarn.domene.SøkerBarnRelasjon
+import no.nav.k9.søknad.felles.type.Språk
 import java.time.LocalDate
 import java.time.ZonedDateTime
 
@@ -29,7 +30,7 @@ object OMPKSSøknadUtils {
         aktørId = "123456",
         fødselsdato = LocalDate.parse("2020-01-01")
     )
-    fun defaultK9Format(søknadId: String, mottatt: ZonedDateTime) = Søknad(
+    fun defaultK9Format(søknadId: String, mottatt: ZonedDateTime, språk: Språk = Språk.NORSK_BOKMÅL) = Søknad(
         SøknadId.of(søknadId),
         Versjon.of("1.0.0"),
         mottatt,
@@ -41,7 +42,7 @@ object OMPKSSøknadUtils {
                 .medNorskIdentitetsnummer(NorskIdentitetsnummer.of("02119970078")),
             true
         )
-    )
+    ).medSpråk(språk)
 
     fun defaultSøknad(søknadId: String, mottatt: ZonedDateTime) = OMPUTVKroniskSyktBarnSøknadMottatt(
         nyVersjon = false,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfGeneratorTest.kt
@@ -308,7 +308,7 @@ class PSBSøknadPdfGeneratorTest {
 
             id = "2-utenSpråk"
             pdf = generator.genererPDF(
-                pdfData = fullGyldigMelding(id).copy(språk = null).pdfData()
+                pdfData = fullGyldigMelding(id).copy(språk = "nb").pdfData()
             )
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
 


### PR DESCRIPTION
- Mapper språk til k9-format for alle ytelsene.
- Utvider Ytelse med felt for nynorsktittel i PDF.
- Utvider PdfData med språk som må implementeres av ytelsene. Bruker så språk for å utlede om man skal bruke nynorsk template eller ikke.
- Alle ytelsene brukes NORSK_BOKMÅL som default språk, unntatt omsorgspenger kronisk sykt barn, som har nynorsk template.