### PR TITLE
TSFF-1073 Støtt nytt format for opplæringspenger Kurs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ repositories {
 
 val tokenSupportVersion = "5.0.14"
 val jsonassertVersion = "1.5.3"
-val k9FormatVersion = "9.8.0"
+val k9FormatVersion = "10.0.1"
 val springMockkVersion = "4.0.2"
 val confluentVersion = "7.3.0"
 val logstashLogbackEncoderVersion = "8.0"

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/Kurs.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/Kurs.kt
@@ -1,38 +1,56 @@
 package no.nav.brukerdialog.ytelse.opplæringspenger.api.domene
 
-import com.fasterxml.jackson.annotation.JsonFormat
+import jakarta.validation.Valid
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
 import no.nav.k9.søknad.felles.type.Periode
 import java.time.LocalDate
-import no.nav.k9.søknad.ytelse.olp.v1.kurs.KursPeriodeMedReisetid as K9KursPeriodeMedReisetid
 import no.nav.k9.søknad.ytelse.olp.v1.kurs.Kursholder as K9Kursholder
+import no.nav.k9.søknad.ytelse.olp.v1.kurs.Kurs as K9Kurs
+import no.nav.k9.søknad.ytelse.olp.v1.kurs.Reise as K9Reise
 
 data class Kurs(
-    val kursholder: String,
-    @field:NotEmpty(message = "Kan ikke være tom liste") val perioder: List<KursPerioderMedReiseTid>
+    @field:NotBlank(message = "Kan ikke være tom") val kursholder: String,
+    @field:NotEmpty(message = "Kan ikke være tom liste") val perioder: List<Periode>,
+    @field:Valid val reise: Reise
 ) {
-    fun tilK9Format(): no.nav.k9.søknad.ytelse.olp.v1.kurs.Kurs {
-        return no.nav.k9.søknad.ytelse.olp.v1.kurs.Kurs(
-            K9Kursholder(null),
-            perioder.map { it.tilK9Format() }
+    fun tilK9Format(): K9Kurs {
+        return K9Kurs(
+            K9Kursholder(kursholder, null),
+            perioder,
+            reise.tilK9Format()
         )
     }
 }
 
-data class KursPerioderMedReiseTid(
-    @JsonFormat(pattern = "yyyy-MM-dd") val avreise: LocalDate,
-    @JsonFormat(pattern = "yyyy-MM-dd") val hjemkomst: LocalDate,
-    val kursperiode: Periode,
-    val harTaptArbeidstid: Boolean,
-    val beskrivelseReisetid: String? = null
-) {
-    fun tilK9Format(): K9KursPeriodeMedReisetid {
-        return K9KursPeriodeMedReisetid(
-            kursperiode,
-            avreise,
-            hjemkomst,
-            beskrivelseReisetid,
-            null
+data class Reise(
+    @field:NotNull(message = "Kan ikke være null") val reiserUtenforKursdager: Boolean,
+    val reisedager: List<LocalDate>? = null,
+    val reisedagerBeskrivelse: String? = null
+){
+    @AssertTrue(message = "Dersom 'reiserUtenforKursdager' er true, kan ikke 'reisedager' være tom liste")
+    fun isReisedagerMedDager(): Boolean {
+        if (reiserUtenforKursdager) {
+            return !reisedager.isNullOrEmpty()
+        }
+        return true
+    }
+
+    @AssertTrue(message = "Dersom 'reiserUtenforKursdager' er true, må man sende med beskrivelse")
+    fun isReisedagerMedBeskrivelse(): Boolean {
+        if (reiserUtenforKursdager) {
+            return !reisedagerBeskrivelse.isNullOrEmpty()
+        }
+        return true
+    }
+
+    fun tilK9Format(): K9Reise {
+        return K9Reise(
+            reiserUtenforKursdager,
+            reisedager,
+            reisedagerBeskrivelse
         )
     }
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
@@ -1,18 +1,16 @@
 package no.nav.brukerdialog.ytelse.opplæringspenger.kafka.domene.felles
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import no.nav.k9.søknad.felles.type.Periode
 import java.time.LocalDate
 
 data class Kurs(
     val kursholder: String,
-    val perioder: List<KursPerioderMedReiseTid>
+    val perioder: List<Periode>,
+    val reise: Reise
 )
 
-data class KursPerioderMedReiseTid(
-    @JsonFormat(pattern = "yyyy-MM-dd") val avreise: LocalDate,
-    @JsonFormat(pattern = "yyyy-MM-dd") val hjemkomst: LocalDate,
-    val kursperiode: Periode,
-    val harTaptArbeidstid: Boolean,
-    val beskrivelseReisetid: String?
+data class Reise(
+    val reiserUtenforKursdager: Boolean,
+    val reisedager: List<LocalDate>? = null,
+    val reisedagerBeskrivelse: String? = null
 )

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
@@ -5,7 +5,6 @@ import no.nav.brukerdialog.common.Constants.DATE_FORMATTER
 import no.nav.brukerdialog.common.Ytelse
 import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils
-import no.nav.brukerdialog.utils.DateUtils.NO_LOCALE
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.DateUtils.somNorskMåned
 import no.nav.brukerdialog.utils.DateUtils.ukeNummer
@@ -15,9 +14,9 @@ import no.nav.brukerdialog.utils.StringUtils.storForbokstav
 import no.nav.brukerdialog.ytelse.opplæringspenger.kafka.domene.OLPMottattSøknad
 import no.nav.brukerdialog.ytelse.opplæringspenger.kafka.domene.capitalizeName
 import no.nav.brukerdialog.ytelse.opplæringspenger.kafka.domene.felles.*
+import no.nav.k9.søknad.felles.type.Periode
 import no.nav.k9.søknad.felles.type.Språk
 import java.time.Month
-import java.time.temporal.WeekFields
 
 class OLPSøknadPdfData(private val søknad: OLPMottattSøknad) : PdfData() {
     override fun ytelse(): Ytelse = Ytelse.OPPLÆRINGSPENGER
@@ -84,21 +83,24 @@ class OLPSøknadPdfData(private val søknad: OLPMottattSøknad) : PdfData() {
 
     private fun Kurs.somMap() = mapOf<String, Any?>(
         "institusjonsnavn" to kursholder,
-        "kursperioder" to perioder.somMapPerioderMedReiseTid()
+        "kursperioder" to perioder.somMap(),
+        "reise" to reise.somMap()
     )
 
-    private fun List<KursPerioderMedReiseTid>.somMapPerioderMedReiseTid(): List<Map<String, Any?>> {
+    private fun List<Periode>.somMap(): List<Map<String, Any?>> {
         return map {
             mapOf<String, Any?>(
-                "fraOgMed" to Constants.DATE_FORMATTER.format(it.kursperiode.fraOgMed),
-                "tilOgMed" to Constants.DATE_FORMATTER.format(it.kursperiode.tilOgMed),
-                "avreise" to Constants.DATE_FORMATTER.format(it.avreise),
-                "hjemkomst" to Constants.DATE_FORMATTER.format(it.hjemkomst),
-                "harTaptArbeidstid" to it.harTaptArbeidstid,
-                "beskrivelseReisetid" to it.beskrivelseReisetid
+                "fraOgMed" to Constants.DATE_FORMATTER.format(it.fraOgMed),
+                "tilOgMed" to Constants.DATE_FORMATTER.format(it.tilOgMed)
             )
         }
     }
+
+    private fun Reise.somMap() = mapOf<String, Any?>(
+        "reiserUtenforKursdager" to reiserUtenforKursdager,
+        "reisedager" to reisedager?.map { Constants.DATE_FORMATTER.format(it) },
+        "reisedagerBeskrivelse" to reisedagerBeskrivelse
+    )
 
     private fun OLPMottattSøknad.harMinstEtArbeidsforhold(): Boolean {
         if (frilans?.arbeidsforhold != null) return true

--- a/src/main/resources/handlebars/opplaeringspenger-soknad.hbs
+++ b/src/main/resources/handlebars/opplaeringspenger-soknad.hbs
@@ -53,23 +53,34 @@
         <p class="sporsmalstekst">Hvor foregår opplæringen?</p>
         <p>{{ kurs.institusjonsnavn }}</p>
         <hr/>
-        <p class="sporsmalstekst">Perioder med opplæring</p>
+        <p class="sporsmalstekst">Hvilke dager søker du opplæringspenger?</p>
         <ul>
             {{#each kurs.kursperioder }}
                 <li>
-                    <p class="sporsmalstekst">{{ fraOgMed }} - {{ tilOgMed }}</p>
-                    <p>Er borte fra jobb på grunn av reise til eller fra opplæringstedet: {{jaNeiSvar harTaptArbeidstid}}</p>
-                    <p>Avreise: {{ avreise }}</p>
-                    <p>Hjemkomst: {{ hjemkomst }}</p>
-                    {{# if beskrivelseReisetid}}
-                        <p>Beskrivelse av reisetid:</p>
-                        <p class="sitat">{{beskrivelseReisetid}}</p>
-                    {{/if}}
-                    <br/>
+                    <p>{{ fraOgMed }} - {{ tilOgMed }}</p>
                 </li>
             {{/each}}
         </ul>
         <hr/>
+
+        <p class="sporsmalstekst">Reiser du på dager du ikke har kurs eller opplæring?</p>
+        <p>{{ jaNeiSvar kurs.reise.reiserUtenforKursdager }}</p>
+        <hr/>
+        {{# if kurs.reise.reiserUtenforKursdager}}
+            <p class="sporsmalstekst">Reisedager uten kurs eller opplæring</p>
+            <ul>
+                {{#each kurs.reise.reisedager as |reisedag|~}}
+                    <li>
+                        <p>{{reisedag}}</p>
+                    </li>
+                {{/each}}
+            </ul>
+            <hr/>
+
+            <p class="sporsmalstekst">Årsak til reisetid</p>
+            <p class="sitat">{{kurs.reise.reisedagerBeskrivelse}}</p>
+            <hr/>
+        {{/if}}
 
         <p class="sporsmalstekst">Skal du ta ut ferie i perioden?</p>
         {{# if ferieuttakIPerioden.skalTaUtFerieIPerioden }}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/K9FormatTest.kt
@@ -191,16 +191,15 @@ class K9FormatTest {
               },
               "kurs" : {
                 "kursholder" : {
-                  "holder" : null,
-                  "institusjonsidentifikator" : null
+                  "institusjonsidentifikator" : null,
+                  "navn" : "Opplæring for kurs AS"
                 },
-                "kursperioder" : [ {
-                  "avreise" : "2022-01-01",
-                  "begrunnelseReisetidHjem" : null,
-                  "begrunnelseReisetidTil" : "Reisetid til kurs tok mer enn en dag",
-                  "hjemkomst" : "2022-01-10",
-                  "periode" : "2022-01-01/2022-01-10"
-                } ]
+                "kursperioder" : [ "2022-01-01/2022-01-10" ],
+                "reise" : {
+                  "reisedager" : [ "2022-01-01", "2022-01-10" ],
+                  "reisedagerBeskrivelse" : "Reise til kurs tok mer enn en dag",
+                  "reiserUtenforKursdager" : true
+                }
               },
               "lovbestemtFerie" : {
                 "perioder" : {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/KursTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/KursTest.kt
@@ -3,10 +3,8 @@ package no.nav.brukerdialog.ytelse.opplæringspenger.api.k9Format
 import no.nav.brukerdialog.utils.TestUtils.Validator
 import no.nav.brukerdialog.utils.TestUtils.verifiserValideringsFeil
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kurs
-import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.KursPerioderMedReiseTid
-import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.fredag
+import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Reise
 import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.mandag
-import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.onsdag
 import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.torsdag
 import no.nav.k9.søknad.felles.type.Periode
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -15,12 +13,10 @@ import org.junit.jupiter.api.Test
 class KursTest {
     private val KJENT_KURSHOLDER = "Kurssenter AS"
 
-    private val STANDARD_KURSPERIODE = KursPerioderMedReiseTid(
-        avreise = mandag,
-        hjemkomst = fredag,
-        kursperiode = Periode(onsdag, torsdag),
-        harTaptArbeidstid = true,
-        beskrivelseReisetid = "Begrunnelse for reise over en dag"
+    private val STANDARD_REISE = Reise(
+        reiserUtenforKursdager = true,
+        reisedager = listOf(mandag, torsdag),
+        reisedagerBeskrivelse = "Begrunnelse for reise"
     )
 
 
@@ -28,28 +24,74 @@ class KursTest {
     fun `Forvent feil derom det sendes tom liste med enkeltdager`() {
         val kurs = Kurs(
             kursholder = KJENT_KURSHOLDER,
-            perioder = emptyList()
+            perioder = emptyList(),
+            reise = STANDARD_REISE
         )
 
         Validator.verifiserValideringsFeil(kurs, 1, "Kan ikke være tom liste")
     }
 
     @Test
+    fun `Forvent feil derom det ikke sendes med navn på kursholder`() {
+        val kurs = Kurs(
+            kursholder = "",
+            perioder = listOf(Periode(mandag, torsdag)),
+            reise = STANDARD_REISE
+        )
+
+        Validator.verifiserValideringsFeil(kurs, 1, "Kan ikke være tom")
+    }
+
+    @Test
+    fun `Forvent feil derom det ikke sendes med beskrivelse for reise`() {
+        val kurs = Kurs(
+            kursholder = KJENT_KURSHOLDER,
+            perioder = listOf(Periode(mandag, torsdag)),
+            reise = Reise(
+                reiserUtenforKursdager = true,
+                reisedager = listOf(mandag, torsdag),
+                reisedagerBeskrivelse = ""
+            )
+        )
+
+        Validator.verifiserValideringsFeil(kurs, 1, "Dersom 'reiserUtenforKursdager' er true, må man sende med beskrivelse")
+    }
+
+    @Test
+    fun `Forvent feil derom det ikke sendes med reisedager`() {
+        val kurs = Kurs(
+            kursholder = KJENT_KURSHOLDER,
+            perioder = listOf(Periode(mandag, torsdag)),
+            reise = Reise(
+                reiserUtenforKursdager = true,
+                reisedager = listOf(),
+                reisedagerBeskrivelse = "Derfor"
+            )
+        )
+
+        Validator.verifiserValideringsFeil(kurs, 1, "Dersom 'reiserUtenforKursdager' er true, kan ikke 'reisedager' være tom liste")
+    }
+
+    @Test
     fun `Kurs med kursholder mappes riktig til k9Format`() {
         val kurs = Kurs(
             kursholder = KJENT_KURSHOLDER,
-            perioder = listOf(STANDARD_KURSPERIODE)
+            perioder = listOf(Periode(mandag, torsdag)),
+            reise = STANDARD_REISE
         )
 
         val k9Kurs = kurs.tilK9Format()
+        val k9Reise = k9Kurs.reise
 
+        assertEquals(kurs.kursholder, k9Kurs.kursholder.navn)
         assertEquals(null, k9Kurs.kursholder.institusjonUuid)
         assertEquals(kurs.perioder.size, k9Kurs.kursperioder.size)
+        assertEquals(kurs.perioder[0].tilOgMed, k9Kurs.kursperioder[0].tilOgMed)
+        assertEquals(kurs.perioder[0].fraOgMed, k9Kurs.kursperioder[0].fraOgMed)
 
-        assertEquals(kurs.perioder[0].avreise, k9Kurs.kursperioder[0].avreise)
-        assertEquals(kurs.perioder[0].hjemkomst, k9Kurs.kursperioder[0].hjemkomst)
-        assertEquals(kurs.perioder[0].kursperiode.tilOgMed, k9Kurs.kursperioder[0].periode.tilOgMed)
-        assertEquals(kurs.perioder[0].kursperiode.fraOgMed, k9Kurs.kursperioder[0].periode.fraOgMed)
-        assertEquals(kurs.perioder[0].beskrivelseReisetid, k9Kurs.kursperioder[0].begrunnelseReisetidTil)
+        assertEquals(kurs.reise.reiserUtenforKursdager, k9Reise.isReiserUtenforKursdager)
+        assertEquals(kurs.reise.reisedagerBeskrivelse, k9Reise.reisedagerBeskrivelse)
+        assertEquals(kurs.reise.reisedager?.size, k9Reise.reisedager.size)
+        assertEquals(kurs.reise.reisedager?.get(0), k9Reise.reisedager[0])
     }
 }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
@@ -267,7 +267,24 @@ class OLPSøknadPdfGeneratorTest {
             )
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
 
-            id = "16-med-relasjon-medmor"
+            id = "16-uten-reise"
+            pdf = generator.genererPDF(
+                pdfData = OlpPdfSøknadUtils.gyldigSøknad(id).copy(
+                    kurs = Kurs(
+                        kursholder = "Senter for Kurs AS",
+                        perioder = listOf(
+                            Periode(LocalDate.parse("2020-01-02"), LocalDate.parse("2020-01-07")),
+                            Periode(LocalDate.parse("2020-03-01"), LocalDate.parse("2020-03-02"))
+                        ),
+                        reise = Reise(
+                            reiserUtenforKursdager = false
+                        )
+                    )
+                ).pdfData()
+            )
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+            id = "17-med-relasjon-medmor"
             pdf = generator.genererPDF(
                 pdfData = OlpPdfSøknadUtils.gyldigSøknad(id).copy(
                     barnRelasjon = BarnRelasjon.MEDMOR,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
@@ -250,25 +250,17 @@ class OLPSøknadPdfGeneratorTest {
                     kurs = Kurs(
                         kursholder = "Senter for Kurs AS",
                         perioder = listOf(
-                            KursPerioderMedReiseTid(
-                                avreise = LocalDate.parse("2020-01-01"),
-                                hjemkomst = LocalDate.parse("2020-01-10"),
-                                kursperiode = Periode(
-                                    LocalDate.parse("2020-01-02"), LocalDate.parse("2020-01-07")
-                                ),
-                                harTaptArbeidstid = true,
-                                beskrivelseReisetid = "Reisetid til kurs tok mer enn en dag. Det var en utrolig lang " +
-                                        "og utmattende reise over fjellet som viste seg å være stengt på grunn av snø."
+                            Periode(LocalDate.parse("2020-01-02"), LocalDate.parse("2020-01-07")),
+                            Periode(LocalDate.parse("2020-03-01"), LocalDate.parse("2020-03-02"))
+                        ),
+                        reise = Reise(
+                            reiserUtenforKursdager = true,
+                            reisedager = listOf(
+                                LocalDate.parse("2020-01-01"),
+                                LocalDate.parse("2020-01-07")
                             ),
-                            KursPerioderMedReiseTid(
-                                avreise = LocalDate.parse("2020-03-01"),
-                                hjemkomst = LocalDate.parse("2020-03-02"),
-                                kursperiode = Periode(
-                                    LocalDate.parse("2020-03-01"), LocalDate.parse("2020-03-02")
-                                ),
-                                harTaptArbeidstid = false,
-                                beskrivelseReisetid = null
-                            )
+                            reisedagerBeskrivelse = "Reisetid til kurs tok mer enn en dag. Det var en utrolig lang " +
+                                    "og utmattende reise over fjellet som viste seg å være stengt på grunn av snø."
                         )
                     )
                 ).pdfData()

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
@@ -138,15 +138,17 @@ object OlpPdfSøknadUtils {
             kurs = Kurs(
                 kursholder = "Senter for Kurs AS",
                 perioder = listOf(
-                    KursPerioderMedReiseTid(
-                        avreise = LocalDate.parse("2020-01-01"),
-                        hjemkomst = LocalDate.parse("2020-01-10"),
-                        kursperiode = Periode(
-                            LocalDate.parse("2020-01-01"), LocalDate.parse("2020-01-10")
-                        ),
-                        harTaptArbeidstid = true,
-                        beskrivelseReisetid = "Reisetid til kurs tok mer enn en dag"
+                    Periode(
+                        LocalDate.parse("2020-01-01"), LocalDate.parse("2020-01-10")
                     )
+                ),
+                reise = Reise(
+                    reiserUtenforKursdager = true,
+                    reisedager = listOf(
+                        LocalDate.parse("2020-01-01"),
+                        LocalDate.parse("2020-01-10")
+                    ),
+                    reisedagerBeskrivelse = "Reisetid til kurs tok mer enn en dag"
                 )
             ),
             opptjeningIUtlandet = listOf(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
@@ -160,16 +160,18 @@ class SøknadUtils {
             kurs = Kurs(
                 kursholder = "Opplæring for kurs AS",
                 perioder = listOf(
-                    KursPerioderMedReiseTid(
-                        avreise = LocalDate.parse("2022-01-01"),
-                        hjemkomst = LocalDate.parse("2022-01-10"),
-                        kursperiode = K9Periode(
-                            LocalDate.parse("2022-01-01"),
-                            LocalDate.parse("2022-01-10")
-                        ),
-                        harTaptArbeidstid = true,
-                        beskrivelseReisetid = "Reisetid til kurs tok mer enn en dag",
+                    K9Periode(
+                        LocalDate.parse("2022-01-01"),
+                        LocalDate.parse("2022-01-10")
                     )
+                ),
+                reise = Reise(
+                    reiserUtenforKursdager = true,
+                    reisedager = listOf(
+                        LocalDate.parse("2022-01-01"),
+                        LocalDate.parse("2022-01-10")
+                    ),
+                    reisedagerBeskrivelse = "Reise til kurs tok mer enn en dag"
                 )
             ),
             utenlandskNæring = listOf(),


### PR DESCRIPTION
### Bakgrunn
I forbindelse med utviklingen av den digitale søknaden for opplæringspenger har `Kurs` endret seg. Endringene er videre beskrevet i Jira: https://jira.adeo.no/browse/TSFF-1073.

### Løsning
* Endrer de datamodellene til Kurs så de samsvarer med frontend.
* Tar i bruk ny kontrakt i k9-format som og skal samsvare med frontend: https://github.com/navikt/k9-format/pull/483
* Fikser pdfen


### Bilder av pdfen
| Oppsummering i frontend | Oppsummering i pdfen |
|--------------------------|-------------------------|
|![Tekster i oppsummering](https://github.com/user-attachments/assets/68f8ab33-a9ee-41dc-a13b-84bbbbe0bbd3)|![image](https://github.com/user-attachments/assets/26e700df-58ce-47bc-947a-98c85d1b7cc6)|

