### PR TITLE
Sender inn arbeid med 0 timer for ikke besvart spm. om arbeid.

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/arbeid/Arbeid.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/arbeid/Arbeid.kt
@@ -8,7 +8,8 @@ internal const val DAGER_PER_UKE = 5L
 enum class ArbeidIPeriodeType {
     ARBEIDER_VANLIG,
     ARBEIDER_REDUSERT,
-    ARBEIDER_IKKE
+    ARBEIDER_IKKE,
+    IKKE_BESVART
 }
 
 enum class RedusertArbeidstidType {

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/arbeid/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/arbeid/Arbeidsforhold.kt
@@ -31,6 +31,7 @@ data class Arbeidsforhold(
         return when (arbeidIPeriode.type) {
             ArbeidIPeriodeType.ARBEIDER_VANLIG -> arbeiderVanlig(fraOgMed, tilOgMed)
             ArbeidIPeriodeType.ARBEIDER_IKKE -> arbeiderIkke(fraOgMed, tilOgMed)
+            ArbeidIPeriodeType.IKKE_BESVART -> arbeiderIkke(fraOgMed, tilOgMed)
             ArbeidIPeriodeType.ARBEIDER_REDUSERT -> arbeiderRedusert(fraOgMed, tilOgMed)
         }
     }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/domene/felles/Arbeid.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/domene/felles/Arbeid.kt
@@ -34,7 +34,8 @@ data class ArbeidsRedusert(
 enum class ArbeidIPeriodeType {
     ARBEIDER_VANLIG,
     ARBEIDER_REDUSERT,
-    ARBEIDER_IKKE;
+    ARBEIDER_IKKE,
+    IKKE_BESVART;
 
     fun jobber() = this != ARBEIDER_IKKE
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfData.kt
@@ -7,6 +7,7 @@ import no.nav.brukerdialog.common.Constants
 import no.nav.brukerdialog.common.Ytelse
 import no.nav.brukerdialog.meldinger.pleiepengersyktbarn.domene.PSBMottattSøknad
 import no.nav.brukerdialog.meldinger.pleiepengersyktbarn.domene.felles.ArbeidIPeriode
+import no.nav.brukerdialog.meldinger.pleiepengersyktbarn.domene.felles.ArbeidIPeriodeType
 import no.nav.brukerdialog.meldinger.pleiepengersyktbarn.domene.felles.ArbeidsRedusert
 import no.nav.brukerdialog.meldinger.pleiepengersyktbarn.domene.felles.ArbeidsUke
 import no.nav.brukerdialog.meldinger.pleiepengersyktbarn.domene.felles.Arbeidsforhold
@@ -234,7 +235,8 @@ class PSBSøknadPdfData(private val søknad: PSBMottattSøknad) : PdfData() {
     private fun Arbeidsforhold.somMap(): Map<String, Any?> = mapOf(
         "data" to this.toString(),
         "normalarbeidstid" to this.normalarbeidstid.somMap(),
-        "arbeidIPeriode" to this.arbeidIPeriode.somMap()
+        "arbeidIPeriode" to this.arbeidIPeriode.somMap(),
+        "skalSkjuleArbeidsgiverUnderSøknadsperioden" to (this.arbeidIPeriode.type == ArbeidIPeriodeType.IKKE_BESVART)
     )
 
     private fun ArbeidIPeriode.somMap(): Map<String, Any?> = mapOf(

--- a/src/main/resources/handlebars/partial/arbeid/arbeidsforholdPartial.hbs
+++ b/src/main/resources/handlebars/partial/arbeid/arbeidsforholdPartial.hbs
@@ -2,6 +2,8 @@
     <ul>
         <li>
             {{#with arbeidsforhold.arbeidIPeriode}}
+                {{#eq type "IKKE_BESVART" }}
+                {{/eq}}
                 {{#eq type "ARBEIDER_IKKE" }}
                     <p>Jobber ikke i perioden.</p>
                 {{/eq}}

--- a/src/main/resources/handlebars/pleiepenger-sykt-barn-soknad.hbs
+++ b/src/main/resources/handlebars/pleiepenger-sykt-barn-soknad.hbs
@@ -296,8 +296,10 @@
             {{#each arbeidsgivere as |arbeidsgiver|~}}
                 <ul class="ul-no-indent">
                     {{#if arbeidsgiver.arbeidsforhold}}
-                        <li><b>{{arbeidsgiver.navn}} (orgnr: {{arbeidsgiver.organisasjonsnummer}})</b></li>
-                        {{> partial/arbeid/arbeidsforholdPartial arbeidsforhold=arbeidsgiver.arbeidsforhold}}
+                        {{#unless arbeidsgiver.arbeidsforhold.skalSkjuleArbeidsgiverUnderSøknadsperioden}}
+                            <li><b>{{arbeidsgiver.navn}} (orgnr: {{arbeidsgiver.organisasjonsnummer}})</b></li>
+                            {{> partial/arbeid/arbeidsforholdPartial arbeidsforhold=arbeidsgiver.arbeidsforhold}}
+                        {{/unless}}
                     {{/if}}
                 </ul>
             {{/each}}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfGeneratorTest.kt
@@ -261,6 +261,19 @@ class PSBSøknadPdfGeneratorTest {
                         )
                     ),
                     Arbeidsgiver(
+                        navn = "Ikke besvart arbeid i periode",
+                        organisasjonsnummer = "917755736",
+                        erAnsatt = false,
+                        arbeidsforhold = Arbeidsforhold(
+                            normalarbeidstid = NormalArbeidstid(
+                                timerPerUkeISnitt = Duration.ofHours(37).plusMinutes(30)
+                            ),
+                            arbeidIPeriode = ArbeidIPeriode(
+                                type = ArbeidIPeriodeType.IKKE_BESVART
+                            )
+                        )
+                    ),
+                    Arbeidsgiver(
                         navn = "Sluttaaaa",
                         organisasjonsnummer = "917755736",
                         erAnsatt = false,


### PR DESCRIPTION
### **Behov / Bakgrunn**
i dag får bruker selv melde fra om at de ikke lengre jobber for en arbeidsgiver, selv om arbeidsforholdet fortsatt er aktivt i Aa-reg. 

Etter lansering av ny inntekt blir dette problematisk, fordi arbeidsforholdet da fjernes fra uttak. Det gjør at beregningen mot inntektsgradering blir feil. 

Det haster å løse denne utfordringen, og vi må derfor i første runde stanse dette i søknaden. Senere kan vi vurdere å gjeninnføre muligheten, og sette arbeidsforholdet som "ikke yrkesaktiv" i uttak, men det krever større analyse/utvikling. 

### **Løsning**
Nå spør vi bruker om de fortsatt jobber for arbeidsgiveren, og vi spør om det skjedde før første søknadsdag. Men: søknaden vet ikke hvilken dato som er skjæringstidspunkt. 

Vi beholder spørsmålet om de fortsatt er ansatt, og gir informasjon om at de må kontakte arbeidsgiver for å bli meldt ut. Vi dropper spørsmålet om dette skjedde før/etter første søknadsdato, og spør om hvor mye de vanligvis jobber i arbeidsforholdet. Vi spør ikke bruker om hvor mye de faktisk jobber for arbeidsgiveren, men sender inn som 0 arbeidstimer sammen med oppgitt normalarbeidstid.

- Legger på ny enum for `ArbeidIPeriodeType `.
- Dersom typen er IKKE_BESVART, sender vi inn 0 faktiskTimer inn til k9-sak.
- Dersom typen er IKKE_BESVART, skjuler vi arbeidsgiveren i PDF-en under seksjon: `Jobb i søknadsperioden`
