### PR TITLE
Legg til støtte for ettersendelse av dokumenter for opplæringspenger

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ repositories {
 
 val tokenSupportVersion = "5.0.16"
 val jsonassertVersion = "1.5.3"
-val k9FormatVersion = "11.2.1"
+val k9FormatVersion = "11.3.0"
 val springMockkVersion = "4.0.2"
 val logstashLogbackEncoderVersion = "8.0"
 val slf4jVersion = "2.0.16"

--- a/src/main/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/dto/YtelseType.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/dto/YtelseType.kt
@@ -147,6 +147,13 @@ enum class YtelseType(
         innsendingstype = Innsendingstype.SØKNAD
     ),
 
+    OPPLÆRINGSPENGERSØKNAD_ETTERSENDING(
+        brevkode = BrevKode(brevKode = "NAVe 09-11.08", dokumentKategori = "SOK"),
+        tittel = "Søknad om opplæringspenger - NAVe 09-11.08",
+        tema = Tema.K9_YTELSER,
+        innsendingstype = Innsendingstype.ETTERSENDELSE
+    ),
+
     FRISINNSØKNAD(
         brevkode = BrevKode(brevKode = "NAV 00-03.02", dokumentKategori = "SOK"),
         tittel = "Søknad om inntektskompensasjon for frilansere og selvstendig næringdrivende - NAV 00-03.02",

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/Søknadstype.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/Søknadstype.kt
@@ -9,7 +9,8 @@ enum class Søknadstype {
     OMP_UT_ARBEIDSTAKER, // Omsorgspenger utbetaling arbeidstaker ytelse.
     OMP_UTV_KS, // Omsorgspenger utvidet rett - kronisk syke eller funksjonshemming.
     OMP_UTV_MA, // Omsorgspenger utvidet rett - midlertidig alene
-    OMP_UTV_AO;
+    OMP_UTV_AO,
+    OPPLÆRINGSPENGER;
 
     fun somK9Ytelse() = when (this) {
         OMP_UTV_KS -> Ytelse.OMP_UTV_KS
@@ -18,5 +19,6 @@ enum class Søknadstype {
         OMP_UT_SNF, OMP_UT_ARBEIDSTAKER -> Ytelse.OMP_UT
         OMP_UTV_AO -> Ytelse.OMP_UTV_AO
         PLEIEPENGER_LIVETS_SLUTTFASE -> Ytelse.PLEIEPENGER_LIVETS_SLUTTFASE
+        OPPLÆRINGSPENGER -> Ytelse.OPPLÆRINGSPENGER
     }
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/kafka/domene/PreprosessertEttersendelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/kafka/domene/PreprosessertEttersendelse.kt
@@ -79,6 +79,7 @@ data class PreprosessertEttersendelse(
         Søknadstype.OMP_UT_ARBEIDSTAKER -> YtelseType.OMSORGSPENGESØKNAD_UTBETALING_ARBEIDSTAKER_ETTERSENDING
         Søknadstype.OMP_UTV_MA -> YtelseType.OMSORGSPENGESØKNAD_MIDLERTIDIG_ALENE_ETTERSENDING
         Søknadstype.OMP_UTV_AO -> YtelseType.OMSORGSDAGER_ALENEOMSORG_ETTERSENDING
+        Søknadstype.OPPLÆRINGSPENGER -> YtelseType.OPPLÆRINGSPENGERSØKNAD_ETTERSENDING
     }
 
     override fun tilK9DittnavVarsel(metadata: MetaInfo): K9Beskjed? = null

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/kafka/domene/Søknadstype.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/kafka/domene/Søknadstype.kt
@@ -8,4 +8,5 @@ enum class Søknadstype(val tittel: String) {
     OMP_UT_ARBEIDSTAKER("Ettersendelse av dokumentasjon til søknad om utbetaling av omsorgspenger når arbeidsgiver ikke utbetaler"),
     OMP_UTV_MA("Ettersendelse av dokumentasjon til søknad om ekstra omsorgsdager når den andre forelderen ikke kan ha tilsyn med barn"),
     OMP_UTV_AO("Ettersendelse av dokumentasjon til søknad om ekstra omsorgsdager ved aleneomsorg"),
+    OPPLÆRINGSPENGER("Ettersendelse av dokumentasjon til søknad om opplæringspenger"),
 }

--- a/src/test/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/DokarkivResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/DokarkivResponseTransformer.kt
@@ -33,7 +33,7 @@ internal class DokarkivResponseTransformer : ResponseTransformer() {
             YtelseType.OMSORGSDAGER_ALENEOMSORG_ETTERSENDING to "18",
             YtelseType.UNGDOMSYTELSE_SØKNAD to "19", // TODO Bruk Tema.UNGDOMSYTELSE før lansering
             YtelseType.UNGDOMSYTELSE_INNTEKTRAPPORTERING to "20", // TODO Bruk Tema.UNGDOMSYTELSE før lansering
-            YtelseType.OPPLÆRINGSPENGERSØKNAD_ETTERSENDING to "21", // Hør med Ramin om dette tallet stemmer
+            YtelseType.OPPLÆRINGSPENGERSØKNAD_ETTERSENDING to "21",
         )
     }
 

--- a/src/test/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/DokarkivResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/DokarkivResponseTransformer.kt
@@ -32,7 +32,8 @@ internal class DokarkivResponseTransformer : ResponseTransformer() {
             YtelseType.PLEIEPENGESØKNAD_LIVETS_SLUTTFASE_ETTERSENDING to "17",
             YtelseType.OMSORGSDAGER_ALENEOMSORG_ETTERSENDING to "18",
             YtelseType.UNGDOMSYTELSE_SØKNAD to "19", // TODO Bruk Tema.UNGDOMSYTELSE før lansering
-            YtelseType.UNGDOMSYTELSE_INNTEKTRAPPORTERING to "20" // TODO Bruk Tema.UNGDOMSYTELSE før lansering
+            YtelseType.UNGDOMSYTELSE_INNTEKTRAPPORTERING to "20", // TODO Bruk Tema.UNGDOMSYTELSE før lansering
+            YtelseType.OPPLÆRINGSPENGERSØKNAD_ETTERSENDING to "21", // Hør med Ramin om dette tallet stemmer
         )
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi ønsker å legge til støtte for digital ettersendelse av dokumenter for opplæringspenger. 

### **Løsning**
Legger til typen `OPPLÆRINGSPENGERSØKNAD_ETTERSENDING` med brevkode: `"NAVe 09-11.08"` som er den samme som i `k9-fordel`. 
