### PR TITLE
Legg inn auto-offset-reset=none for kafka strømmene til olp

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -242,13 +242,13 @@ no.nav:
 
       olp-soknad-preprosessering:
         application-id-suffix: olp-soknad-preprosessering
-        auto-offset-reset: earliest
+        auto-offset-reset: none
       olp-soknad-journalforing:
         application-id-suffix: olp-soknad-journalforing
-        auto-offset-reset: earliest
+        auto-offset-reset: none
       olp-soknad-cleanup:
         application-id-suffix: olp-soknad-cleanup
-        auto-offset-reset: earliest
+        auto-offset-reset: none
 
 management:
   endpoint:


### PR DESCRIPTION
### **Behov / Bakgrunn**
Digital søknad for opplæringspenger er i prod og vi passe på at meldingene blir konsumert riktig.

### **Løsning**
Sette `auto-offset-reset` til `none` i olp-soknad-* streamene nå som første mottatte søknad i prod.