### PR TITLE
Skjuler søknadId og mottatt felt for swagger.

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/Ettersendelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/Ettersendelse.kt
@@ -1,5 +1,6 @@
 package no.nav.brukerdialog.ytelse.ettersendelse.api.domene
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotEmpty
@@ -21,9 +22,14 @@ import java.time.ZonedDateTime
 import java.util.*
 
 data class Ettersendelse(
-    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'") val søknadId: String = UUID.randomUUID().toString(),
+    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
+    val søknadId: String = UUID.randomUUID().toString(),
     val språk: String,
+
+    @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
+
     @field:NotEmpty(message = "Kan ikke være tom") val vedlegg: List<URL>,
     val beskrivelse: String? = null,
     val søknadstype: Søknadstype,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/api/domene/OmsorgspengerutbetalingArbeidstakerSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/api/domene/OmsorgspengerutbetalingArbeidstakerSøknad.kt
@@ -1,5 +1,6 @@
 package no.nav.brukerdialog.ytelse.omsorgpengerutbetalingat.api.domene
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotEmpty
 import no.nav.k9.søknad.Søknad
@@ -35,7 +36,10 @@ private val k9FormatVersjon = Versjon.of("1.1.0")
 
 data class OmsorgspengerutbetalingArbeidstakerSøknad(
     @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
     val søknadId: String = UUID.randomUUID().toString(),
+
+    @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
     val språk: String,
     val vedlegg: List<URL>,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/api/domene/OmsorgspengerutbetalingSnfSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/api/domene/OmsorgspengerutbetalingSnfSøknad.kt
@@ -1,5 +1,6 @@
 package no.nav.brukerdialog.ytelse.omsorgpengerutbetalingsnf.api.domene
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import no.nav.k9.søknad.Søknad
 import no.nav.k9.søknad.SøknadValidator
@@ -35,8 +36,12 @@ import no.nav.k9.søknad.Søknad as K9Søknad
 
 data class OmsorgspengerutbetalingSnfSøknad(
     @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
-    internal val søknadId: String = UUID.randomUUID().toString(),
+    @Schema(hidden = true)
+    val søknadId: String = UUID.randomUUID().toString(),
+
+    @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
+    
     val språk: String,
     val søkerNorskIdent: String? = null, // TODO: Fjern nullable når vi har lansert og mellomlagring inneholder dette feltet.
     @field:Valid val bosteder: List<Bosted>,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneOmOmsorgenSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneOmOmsorgenSøknad.kt
@@ -1,5 +1,6 @@
 package no.nav.brukerdialog.ytelse.omsorgspengeraleneomsorg.api.domene
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotEmpty
@@ -26,8 +27,10 @@ import no.nav.k9.søknad.Søknad as K9Søknad
 
 data class OmsorgsdagerAleneOmOmsorgenSøknad(
     @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
     val søknadId: String = UUID.randomUUID().toString(),
 
+    @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
     val språk: String,
     val søkerNorskIdent: String? = null, // TODO: Fjern nullable når vi har lansert og mellomlagring inneholder dette feltet.

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerKroniskSyktBarnSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerKroniskSyktBarnSøknad.kt
@@ -1,5 +1,6 @@
 package no.nav.brukerdialog.ytelse.omsorgspengerkronisksyktbarn.api.domene
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotNull
@@ -28,8 +29,13 @@ import java.util.*
 import no.nav.k9.søknad.Søknad as K9Søknad
 
 data class OmsorgspengerKroniskSyktBarnSøknad(
-    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'") val søknadId: String = UUID.randomUUID().toString(),
+    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
+    val søknadId: String = UUID.randomUUID().toString(),
+
+    @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
+
     val språk: String,
     @field:Valid var barn: Barn,
     val legeerklæring: List<URL> = listOf(),

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMidlertidigAleneSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMidlertidigAleneSøknad.kt
@@ -1,5 +1,6 @@
 package no.nav.brukerdialog.ytelse.omsorgspengermidlertidigalene.api.domene
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotEmpty
@@ -26,7 +27,10 @@ import no.nav.k9.søknad.Søknad as K9Søknad
 
 data class OmsorgspengerMidlertidigAleneSøknad(
     @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
     val søknadId: String = UUID.randomUUID().toString(),
+
+    @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
     val id: String,
     val språk: String,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/OpplæringspengerSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/OpplæringspengerSøknad.kt
@@ -1,6 +1,7 @@
 package no.nav.brukerdialog.ytelse.opplæringspenger.api.domene
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
 import no.nav.brukerdialog.common.MetaInfo
@@ -50,9 +51,11 @@ data class OpplæringspengerSøknad(
     val apiDataVersjon: String? = null,
 
     @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
     val søknadId: String = UUID.randomUUID().toString(),
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
+    @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
     val språk: Språk,
     val søkerNorskIdent: String? = null, // TODO: Fjern nullable når vi har lansert og mellomlagring inneholder dette feltet.

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/api/domene/PleiepengerILivetsSluttfaseSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/api/domene/PleiepengerILivetsSluttfaseSøknad.kt
@@ -1,13 +1,28 @@
 package no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
+import no.nav.brukerdialog.common.MetaInfo
+import no.nav.brukerdialog.domenetjenester.innsending.Innsending
+import no.nav.brukerdialog.integrasjon.k9mellomlagring.dokumentId
+import no.nav.brukerdialog.oppslag.soker.Søker
+import no.nav.brukerdialog.utils.krever
+import no.nav.brukerdialog.validation.ValidationErrorResponseException
+import no.nav.brukerdialog.validation.ValidationProblemDetailsString
+import no.nav.brukerdialog.ytelse.Ytelse
+import no.nav.brukerdialog.ytelse.fellesdomene.ArbeidUtils.SYV_OG_EN_HALV_TIME
+import no.nav.brukerdialog.ytelse.fellesdomene.ArbeidUtils.arbeidstidInfoMedNullTimer
+import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.Arbeidsgiver.Companion.somK9Arbeidstaker
+import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.OpptjeningIUtlandet.Companion.valider
+import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.UtenlandskNæring.Companion.valider
 import no.nav.k9.søknad.Søknad
 import no.nav.k9.søknad.SøknadValidator
 import no.nav.k9.søknad.felles.Kildesystem
 import no.nav.k9.søknad.felles.Versjon
 import no.nav.k9.søknad.felles.opptjening.OpptjeningAktivitet
 import no.nav.k9.søknad.felles.type.Periode
+import no.nav.k9.søknad.felles.type.Språk
 import no.nav.k9.søknad.felles.type.SøknadId
 import no.nav.k9.søknad.ytelse.DataBruktTilUtledning
 import no.nav.k9.søknad.ytelse.pls.v1.PleiepengerLivetsSluttfaseSøknadValidator
@@ -15,20 +30,6 @@ import no.nav.k9.søknad.ytelse.pls.v1.PleipengerLivetsSluttfase
 import no.nav.k9.søknad.ytelse.psb.v1.Uttak
 import no.nav.k9.søknad.ytelse.psb.v1.Uttak.UttakPeriodeInfo
 import no.nav.k9.søknad.ytelse.psb.v1.arbeidstid.Arbeidstid
-import no.nav.brukerdialog.domenetjenester.innsending.Innsending
-import no.nav.brukerdialog.ytelse.Ytelse
-import no.nav.brukerdialog.ytelse.fellesdomene.ArbeidUtils.SYV_OG_EN_HALV_TIME
-import no.nav.brukerdialog.ytelse.fellesdomene.ArbeidUtils.arbeidstidInfoMedNullTimer
-import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.Arbeidsgiver.Companion.somK9Arbeidstaker
-import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.OpptjeningIUtlandet.Companion.valider
-import no.nav.brukerdialog.ytelse.pleiepengerilivetsslutttfase.api.domene.UtenlandskNæring.Companion.valider
-import no.nav.brukerdialog.common.MetaInfo
-import no.nav.brukerdialog.integrasjon.k9mellomlagring.dokumentId
-import no.nav.brukerdialog.oppslag.soker.Søker
-import no.nav.brukerdialog.utils.krever
-import no.nav.brukerdialog.validation.ValidationErrorResponseException
-import no.nav.brukerdialog.validation.ValidationProblemDetailsString
-import no.nav.k9.søknad.felles.type.Språk
 import java.net.URL
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -37,13 +38,19 @@ import java.util.*
 import no.nav.k9.søknad.Søknad as K9Søknad
 
 data class PleiepengerILivetsSluttfaseSøknad(
-    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'") internal val søknadId: String = UUID.randomUUID().toString(),
+    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
+    val søknadId: String = UUID.randomUUID().toString(),
+
     val språk: String,
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate,
     val skalJobbeOgPleieSammeDag: Boolean,
     val dagerMedPleie: List<LocalDate>,
+
+    @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
+
     val vedleggUrls: List<URL> = listOf(),
     val opplastetIdVedleggUrls: List<URL> = listOf(),
     @field:Valid val pleietrengende: Pleietrengende,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/api/domene/Endringsmelding.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/api/domene/Endringsmelding.kt
@@ -1,5 +1,6 @@
 package no.nav.brukerdialog.ytelse.pleiepengersyktbarn.endringsmelding.api.domene
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
 import no.nav.k9.søknad.Søknad
@@ -24,7 +25,11 @@ import java.util.*
 import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 
 data class Endringsmelding(
-    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'") val søknadId: String = UUID.randomUUID().toString(),
+    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
+    val søknadId: String = UUID.randomUUID().toString(),
+
+    @Schema(hidden = true)
     val mottattDato: ZonedDateTime? = ZonedDateTime.now(UTC),
     val språk: String,
     var pleietrengendeNavn: String? = null,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/PleiepengerSyktBarnSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/PleiepengerSyktBarnSøknad.kt
@@ -1,6 +1,7 @@
 package no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.api.domene
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
 import no.nav.brukerdialog.domenetjenester.innsending.Innsending
@@ -45,10 +46,15 @@ private val k9FormatVersjon = Versjon.of("1.0.0")
 data class PleiepengerSyktBarnSøknad(
     val newVersion: Boolean?,
     val apiDataVersjon: String? = null,
-    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'") val søknadId: String = UUID.randomUUID()
-        .toString(),
+
+    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
+    val søknadId: String = UUID.randomUUID().toString(),
+
+    @Schema(hidden = true)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
+
     val språk: Språk,
     val søkerNorskIdent: String? = null, // TODO: Fjern nullable når vi har lansert og mellomlagring inneholder dette feltet.
     @field:Valid val barn: BarnDetaljer,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
@@ -1,5 +1,6 @@
 package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.AssertTrue
 import no.nav.brukerdialog.common.MetaInfo
 import no.nav.brukerdialog.domenetjenester.innsending.Innsending
@@ -23,9 +24,13 @@ import no.nav.k9.søknad.Søknad as UngSøknad
 
 data class Ungdomsytelsesøknad(
     @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @Schema(hidden = true)
     val søknadId: String = UUID.randomUUID().toString(),
     val språk: String,
+
+    @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
+
     val startdato: LocalDate,
     val søkerNorskIdent: String,
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved autogenerering av typescriptkode for disse input klassene blir søknadId og mottatt feltene lagt på som påkrevde felter.

### **Løsning**
Skjuler disse feltene for swagger, slik at de ikke blir inkludert i skjemaet.

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
