### PR TITLE
Legg til støtte for å motta uuid for kursholder – opplæringspenger

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/Kurs.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/Kurs.kt
@@ -8,21 +8,31 @@ import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import no.nav.k9.søknad.felles.type.Periode
 import java.time.LocalDate
+import java.util.UUID
 import no.nav.k9.søknad.ytelse.olp.v1.kurs.Kursholder as K9Kursholder
 import no.nav.k9.søknad.ytelse.olp.v1.kurs.Kurs as K9Kurs
 import no.nav.k9.søknad.ytelse.olp.v1.kurs.Reise as K9Reise
 
 data class Kurs(
-    @field:NotBlank(message = "Kan ikke være tom") val kursholder: String,
+    @field:Valid val kursholder: Kursholder,
     @field:NotEmpty(message = "Kan ikke være tom liste") val kursperioder: List<Periode>,
     @field:Valid val reise: Reise
 ) {
     fun tilK9Format(): K9Kurs {
         return K9Kurs(
-            K9Kursholder(kursholder, null),
+            kursholder.tilK9Format(),
             kursperioder,
             reise.tilK9Format()
         )
+    }
+}
+
+data class Kursholder(
+    val uuid: UUID,
+    @field:NotBlank(message = "Kan ikke være tom") val navn: String
+){
+    fun tilK9Format(): K9Kursholder {
+        return K9Kursholder(navn, uuid)
     }
 }
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/Kurs.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/Kurs.kt
@@ -28,7 +28,7 @@ data class Kurs(
 }
 
 data class Kursholder(
-    val uuid: UUID,
+    val uuid: UUID? = null,
     @field:NotBlank(message = "Kan ikke være tom") val navn: String
 ){
     fun tilK9Format(): K9Kursholder {

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/Kurs.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/Kurs.kt
@@ -1,5 +1,10 @@
 package no.nav.brukerdialog.ytelse.opplæringspenger.api.domene
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.Hidden
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
@@ -14,7 +19,7 @@ import no.nav.k9.søknad.ytelse.olp.v1.kurs.Kurs as K9Kurs
 import no.nav.k9.søknad.ytelse.olp.v1.kurs.Reise as K9Reise
 
 data class Kurs(
-    @field:Valid val kursholder: Kursholder,
+    @field:Valid val kursholder: KursholderType,
     @field:NotEmpty(message = "Kan ikke være tom liste") val kursperioder: List<Periode>,
     @field:Valid val reise: Reise
 ) {
@@ -27,12 +32,41 @@ data class Kurs(
     }
 }
 
-data class Kursholder(
-    val uuid: UUID? = null,
-    @field:NotBlank(message = "Kan ikke være tom") val navn: String
-){
-    fun tilK9Format(): K9Kursholder {
-        return K9Kursholder(navn, uuid)
+@JsonDeserialize(using = KursholderTypeDeserializer::class)
+sealed class KursholderType {
+    abstract fun tilK9Format(): K9Kursholder
+
+    data class Kursholder(
+        val uuid: UUID? = null,
+        @field:NotBlank(message = "Kan ikke være tom") val navn: String
+    ) : KursholderType() {
+        override fun tilK9Format(): K9Kursholder {
+            return K9Kursholder(navn, uuid)
+        }
+    }
+
+    data class KursholderNavn(
+        @field:NotBlank(message = "Kan ikke være tom") val navn: String
+    ) : KursholderType() {
+        override fun tilK9Format(): K9Kursholder {
+            return K9Kursholder(navn, null)
+        }
+    }
+}
+
+class KursholderTypeDeserializer : JsonDeserializer<KursholderType>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): KursholderType {
+        val node: JsonNode = p.codec.readTree(p)
+        return if (node.has("uuid")) {
+            KursholderType.Kursholder(
+                uuid = node.get("uuid")?.let { UUID.fromString(it.asText()) },
+                navn = node.get("navn").asText()
+            )
+        } else {
+            KursholderType.KursholderNavn(
+                navn = node.get("navn").asText()
+            )
+        }
     }
 }
 
@@ -40,7 +74,7 @@ data class Reise(
     @field:NotNull(message = "Kan ikke være null") val reiserUtenforKursdager: Boolean,
     val reisedager: List<LocalDate>? = null,
     val reisedagerBeskrivelse: String? = null
-){
+) {
     @Hidden
     @AssertTrue(message = "Dersom 'reiserUtenforKursdager' er true, kan ikke 'reisedager' være tom liste")
     fun isReisedagerMedDager(): Boolean {

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
@@ -2,11 +2,17 @@ package no.nav.brukerdialog.ytelse.opplæringspenger.kafka.domene.felles
 
 import no.nav.k9.søknad.felles.type.Periode
 import java.time.LocalDate
+import java.util.*
 
 data class Kurs(
-    val kursholder: String,
+    val kursholder: Kursholder,
     val kursperioder: List<Periode>,
     val reise: Reise
+)
+
+data class Kursholder(
+    val uuid: UUID,
+    val navn: String
 )
 
 data class Reise(

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
@@ -1,44 +1,22 @@
 package no.nav.brukerdialog.ytelse.opplæringspenger.kafka.domene.felles
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import no.nav.k9.søknad.felles.type.Periode
 import java.time.LocalDate
 import java.util.*
 
 data class Kurs(
-    val kursholder: KursholderType,
+    val kursholder: Kursholder,
     val kursperioder: List<Periode>,
     val reise: Reise
 )
 
-@JsonDeserialize(using = KursholderTypeDeserializer::class)
-sealed class KursholderType {
-    data class Kursholder(val uuid: UUID? = null, val navn: String) : KursholderType()
-    data class KursholderNavn(val navn: String) : KursholderType()
-}
+data class Kursholder(
+    val uuid: UUID? = null,
+    val navn: String
+)
 
 data class Reise(
     val reiserUtenforKursdager: Boolean,
     val reisedager: List<LocalDate>? = null,
     val reisedagerBeskrivelse: String? = null
 )
-
-class KursholderTypeDeserializer : JsonDeserializer<KursholderType>() {
-    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): KursholderType {
-        val node: JsonNode = p.codec.readTree(p)
-        return if (node.has("uuid")) {
-            KursholderType.Kursholder(
-                uuid = node.get("uuid")?.let { UUID.fromString(it.asText()) },
-                navn = node.get("navn").asText()
-            )
-        } else {
-            KursholderType.KursholderNavn(
-                navn = node.get("navn").asText()
-            )
-        }
-    }
-}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
@@ -1,22 +1,44 @@
 package no.nav.brukerdialog.ytelse.opplæringspenger.kafka.domene.felles
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import no.nav.k9.søknad.felles.type.Periode
 import java.time.LocalDate
 import java.util.*
 
 data class Kurs(
-    val kursholder: Kursholder,
+    val kursholder: KursholderType,
     val kursperioder: List<Periode>,
     val reise: Reise
 )
 
-data class Kursholder(
-    val uuid: UUID? = null,
-    val navn: String
-)
+@JsonDeserialize(using = KursholderTypeDeserializer::class)
+sealed class KursholderType {
+    data class Kursholder(val uuid: UUID? = null, val navn: String) : KursholderType()
+    data class KursholderNavn(val navn: String) : KursholderType()
+}
 
 data class Reise(
     val reiserUtenforKursdager: Boolean,
     val reisedager: List<LocalDate>? = null,
     val reisedagerBeskrivelse: String? = null
 )
+
+class KursholderTypeDeserializer : JsonDeserializer<KursholderType>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): KursholderType {
+        val node: JsonNode = p.codec.readTree(p)
+        return if (node.has("uuid")) {
+            KursholderType.Kursholder(
+                uuid = node.get("uuid")?.let { UUID.fromString(it.asText()) },
+                navn = node.get("navn").asText()
+            )
+        } else {
+            KursholderType.KursholderNavn(
+                navn = node.get("navn").asText()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Kurs.kt
@@ -11,7 +11,7 @@ data class Kurs(
 )
 
 data class Kursholder(
-    val uuid: UUID,
+    val uuid: UUID? = null,
     val navn: String
 )
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
@@ -82,17 +82,10 @@ class OLPSøknadPdfData(private val søknad: OLPMottattSøknad) : PdfData() {
     )
 
     private fun Kurs.somMap() = mapOf<String, Any?>(
-        "institusjonsnavn" to kursholder.navn(),
+        "institusjonsnavn" to kursholder.navn,
         "kursperioder" to kursperioder.somMap(),
         "reise" to reise.somMap()
     )
-
-    private fun KursholderType.navn(): String {
-        return when (this) {
-            is KursholderType.Kursholder -> navn
-            is KursholderType.KursholderNavn -> navn
-        }
-    }
 
     private fun List<Periode>.somMap(): List<Map<String, Any?>> {
         return map {

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
@@ -82,7 +82,7 @@ class OLPSøknadPdfData(private val søknad: OLPMottattSøknad) : PdfData() {
     )
 
     private fun Kurs.somMap() = mapOf<String, Any?>(
-        "institusjonsnavn" to kursholder,
+        "institusjonsnavn" to kursholder.navn,
         "kursperioder" to kursperioder.somMap(),
         "reise" to reise.somMap()
     )

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
@@ -82,10 +82,17 @@ class OLPSøknadPdfData(private val søknad: OLPMottattSøknad) : PdfData() {
     )
 
     private fun Kurs.somMap() = mapOf<String, Any?>(
-        "institusjonsnavn" to kursholder.navn,
+        "institusjonsnavn" to kursholder.navn(),
         "kursperioder" to kursperioder.somMap(),
         "reise" to reise.somMap()
     )
+
+    private fun KursholderType.navn(): String {
+        return when (this) {
+            is KursholderType.Kursholder -> navn
+            is KursholderType.KursholderNavn -> navn
+        }
+    }
 
     private fun List<Periode>.somMap(): List<Map<String, Any?>> {
         return map {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/K9FormatTest.kt
@@ -191,8 +191,8 @@ class K9FormatTest {
               },
               "kurs" : {
                 "kursholder" : {
-                  "institusjonsidentifikator" : null,
-                  "navn" : "Opplæring for kurs AS"
+                  "institusjonsidentifikator" : "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+                  "navn" : "Senter for Kurs AS"
                 },
                 "kursperioder" : [ "2022-01-01/2022-01-10" ],
                 "reise" : {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/KursTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/KursTest.kt
@@ -3,7 +3,7 @@ package no.nav.brukerdialog.ytelse.opplæringspenger.api.k9Format
 import no.nav.brukerdialog.utils.TestUtils.Validator
 import no.nav.brukerdialog.utils.TestUtils.verifiserValideringsFeil
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kurs
-import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kursholder
+import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.KursholderType
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Reise
 import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.mandag
 import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.torsdag
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import java.util.*
 
 class KursTest {
-    private val KJENT_KURSHOLDER = Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), "Kurssenter AS")
+    private val KJENT_KURSHOLDER = KursholderType.Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), "Kurssenter AS")
 
     private val STANDARD_REISE = Reise(
         reiserUtenforKursdager = true,
@@ -36,7 +36,7 @@ class KursTest {
     @Test
     fun `Forvent feil derom det ikke sendes med navn på kursholder`() {
         val kurs = Kurs(
-            kursholder = Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), ""),
+            kursholder = KursholderType.Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), ""),
             kursperioder = listOf(Periode(mandag, torsdag)),
             reise = STANDARD_REISE
         )
@@ -85,8 +85,8 @@ class KursTest {
         val k9Kurs = kurs.tilK9Format()
         val k9Reise = k9Kurs.reise
 
-        assertEquals(kurs.kursholder.navn, k9Kurs.kursholder.navn)
-        assertEquals(kurs.kursholder.uuid, k9Kurs.kursholder.institusjonUuid)
+        assertEquals((kurs.kursholder as KursholderType.Kursholder).navn, k9Kurs.kursholder.navn)
+        assertEquals((kurs.kursholder as KursholderType.Kursholder).uuid, k9Kurs.kursholder.institusjonUuid)
         assertEquals(kurs.kursperioder.size, k9Kurs.kursperioder.size)
         assertEquals(kurs.kursperioder[0].tilOgMed, k9Kurs.kursperioder[0].tilOgMed)
         assertEquals(kurs.kursperioder[0].fraOgMed, k9Kurs.kursperioder[0].fraOgMed)

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/KursTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/KursTest.kt
@@ -3,7 +3,7 @@ package no.nav.brukerdialog.ytelse.opplæringspenger.api.k9Format
 import no.nav.brukerdialog.utils.TestUtils.Validator
 import no.nav.brukerdialog.utils.TestUtils.verifiserValideringsFeil
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kurs
-import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.KursholderType
+import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kursholder
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Reise
 import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.mandag
 import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.torsdag
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import java.util.*
 
 class KursTest {
-    private val KJENT_KURSHOLDER = KursholderType.Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), "Kurssenter AS")
+    private val KJENT_KURSHOLDER = Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), "Kurssenter AS")
 
     private val STANDARD_REISE = Reise(
         reiserUtenforKursdager = true,
@@ -36,7 +36,7 @@ class KursTest {
     @Test
     fun `Forvent feil derom det ikke sendes med navn på kursholder`() {
         val kurs = Kurs(
-            kursholder = KursholderType.Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), ""),
+            kursholder = Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), ""),
             kursperioder = listOf(Periode(mandag, torsdag)),
             reise = STANDARD_REISE
         )
@@ -85,8 +85,8 @@ class KursTest {
         val k9Kurs = kurs.tilK9Format()
         val k9Reise = k9Kurs.reise
 
-        assertEquals((kurs.kursholder as KursholderType.Kursholder).navn, k9Kurs.kursholder.navn)
-        assertEquals((kurs.kursholder as KursholderType.Kursholder).uuid, k9Kurs.kursholder.institusjonUuid)
+        assertEquals(kurs.kursholder.navn, k9Kurs.kursholder.navn)
+        assertEquals(kurs.kursholder.uuid, k9Kurs.kursholder.institusjonUuid)
         assertEquals(kurs.kursperioder.size, k9Kurs.kursperioder.size)
         assertEquals(kurs.kursperioder[0].tilOgMed, k9Kurs.kursperioder[0].tilOgMed)
         assertEquals(kurs.kursperioder[0].fraOgMed, k9Kurs.kursperioder[0].fraOgMed)

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/KursTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/KursTest.kt
@@ -3,15 +3,17 @@ package no.nav.brukerdialog.ytelse.opplæringspenger.api.k9Format
 import no.nav.brukerdialog.utils.TestUtils.Validator
 import no.nav.brukerdialog.utils.TestUtils.verifiserValideringsFeil
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kurs
+import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kursholder
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Reise
 import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.mandag
 import no.nav.brukerdialog.ytelse.opplæringspenger.utils.OLPTestUtils.torsdag
 import no.nav.k9.søknad.felles.type.Periode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.util.*
 
 class KursTest {
-    private val KJENT_KURSHOLDER = "Kurssenter AS"
+    private val KJENT_KURSHOLDER = Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), "Kurssenter AS")
 
     private val STANDARD_REISE = Reise(
         reiserUtenforKursdager = true,
@@ -34,7 +36,7 @@ class KursTest {
     @Test
     fun `Forvent feil derom det ikke sendes med navn på kursholder`() {
         val kurs = Kurs(
-            kursholder = "",
+            kursholder = Kursholder(UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), ""),
             kursperioder = listOf(Periode(mandag, torsdag)),
             reise = STANDARD_REISE
         )
@@ -83,8 +85,8 @@ class KursTest {
         val k9Kurs = kurs.tilK9Format()
         val k9Reise = k9Kurs.reise
 
-        assertEquals(kurs.kursholder, k9Kurs.kursholder.navn)
-        assertEquals(null, k9Kurs.kursholder.institusjonUuid)
+        assertEquals(kurs.kursholder.navn, k9Kurs.kursholder.navn)
+        assertEquals(kurs.kursholder.uuid, k9Kurs.kursholder.institusjonUuid)
         assertEquals(kurs.kursperioder.size, k9Kurs.kursperioder.size)
         assertEquals(kurs.kursperioder[0].tilOgMed, k9Kurs.kursperioder[0].tilOgMed)
         assertEquals(kurs.kursperioder[0].fraOgMed, k9Kurs.kursperioder[0].fraOgMed)

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
@@ -250,7 +250,7 @@ class OLPSøknadPdfGeneratorTest {
             pdf = generator.genererPDF(
                 pdfData = OlpPdfSøknadUtils.gyldigSøknad(id).copy(
                     kurs = Kurs(
-                        kursholder = Kursholder(
+                        kursholder = KursholderType.Kursholder(
                             UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
                             "Senter for Kurs AS"
                         ),
@@ -276,7 +276,7 @@ class OLPSøknadPdfGeneratorTest {
             pdf = generator.genererPDF(
                 pdfData = OlpPdfSøknadUtils.gyldigSøknad(id).copy(
                     kurs = Kurs(
-                        kursholder = Kursholder(
+                        kursholder = KursholderType.Kursholder(
                             UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
                             "Senter for Kurs AS"
                         ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
@@ -250,7 +250,7 @@ class OLPSøknadPdfGeneratorTest {
             pdf = generator.genererPDF(
                 pdfData = OlpPdfSøknadUtils.gyldigSøknad(id).copy(
                     kurs = Kurs(
-                        kursholder = KursholderType.Kursholder(
+                        kursholder = Kursholder(
                             UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
                             "Senter for Kurs AS"
                         ),
@@ -276,7 +276,7 @@ class OLPSøknadPdfGeneratorTest {
             pdf = generator.genererPDF(
                 pdfData = OlpPdfSøknadUtils.gyldigSøknad(id).copy(
                     kurs = Kurs(
-                        kursholder = KursholderType.Kursholder(
+                        kursholder = Kursholder(
                             UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
                             "Senter for Kurs AS"
                         ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
@@ -10,6 +10,7 @@ import java.io.File
 import java.time.Duration
 import java.time.LocalDate
 import java.time.ZonedDateTime
+import java.util.*
 
 class OLPSøknadPdfGeneratorTest {
 
@@ -249,7 +250,10 @@ class OLPSøknadPdfGeneratorTest {
             pdf = generator.genererPDF(
                 pdfData = OlpPdfSøknadUtils.gyldigSøknad(id).copy(
                     kurs = Kurs(
-                        kursholder = "Senter for Kurs AS",
+                        kursholder = Kursholder(
+                            UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+                            "Senter for Kurs AS"
+                        ),
                         kursperioder = listOf(
                             Periode(LocalDate.parse("2020-01-02"), LocalDate.parse("2020-01-07")),
                             Periode(LocalDate.parse("2020-03-01"), LocalDate.parse("2020-03-02"))
@@ -272,7 +276,10 @@ class OLPSøknadPdfGeneratorTest {
             pdf = generator.genererPDF(
                 pdfData = OlpPdfSøknadUtils.gyldigSøknad(id).copy(
                     kurs = Kurs(
-                        kursholder = "Senter for Kurs AS",
+                        kursholder = Kursholder(
+                            UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+                            "Senter for Kurs AS"
+                        ),
                         kursperioder = listOf(
                             Periode(LocalDate.parse("2020-01-02"), LocalDate.parse("2020-01-07")),
                             Periode(LocalDate.parse("2020-03-01"), LocalDate.parse("2020-03-02"))

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
@@ -139,7 +139,7 @@ object OlpPdfSøknadUtils {
             harVærtEllerErVernepliktig = true,
             k9FormatSøknad = K9FormatUtils.defaultK9FormatPSB(soknadsId, mottatt),
             kurs = Kurs(
-                kursholder = KursholderType.Kursholder(
+                kursholder = Kursholder(
                     UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
                     "Senter for Kurs AS"
                 ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
@@ -8,6 +8,7 @@ import no.nav.k9.søknad.felles.type.Periode
 import java.time.Duration
 import java.time.LocalDate
 import java.time.ZonedDateTime
+import java.util.*
 
 
 object OlpPdfSøknadUtils {
@@ -138,7 +139,10 @@ object OlpPdfSøknadUtils {
             harVærtEllerErVernepliktig = true,
             k9FormatSøknad = K9FormatUtils.defaultK9FormatPSB(soknadsId, mottatt),
             kurs = Kurs(
-                kursholder = "Senter for Kurs AS",
+                kursholder = Kursholder(
+                    UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+                    "Senter for Kurs AS"
+                ),
                 kursperioder = listOf(
                     Periode(
                         LocalDate.parse("2020-01-01"), LocalDate.parse("2020-01-10")

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
@@ -139,7 +139,7 @@ object OlpPdfSøknadUtils {
             harVærtEllerErVernepliktig = true,
             k9FormatSøknad = K9FormatUtils.defaultK9FormatPSB(soknadsId, mottatt),
             kurs = Kurs(
-                kursholder = Kursholder(
+                kursholder = KursholderType.Kursholder(
                     UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
                     "Senter for Kurs AS"
                 ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
@@ -6,6 +6,7 @@ import no.nav.brukerdialog.ytelse.fellesdomene.Næringstype
 import no.nav.brukerdialog.ytelse.fellesdomene.Virksomhet
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.*
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.arbeid.*
+import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kursholder
 import java.net.URI
 import java.time.Duration
 import java.time.LocalDate
@@ -158,7 +159,10 @@ class SøknadUtils {
                 )
             ),
             kurs = Kurs(
-                kursholder = "Opplæring for kurs AS",
+                kursholder = Kursholder(
+                    UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+                    "Senter for Kurs AS"
+                ),
                 kursperioder = listOf(
                     K9Periode(
                         LocalDate.parse("2022-01-01"),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
@@ -6,7 +6,6 @@ import no.nav.brukerdialog.ytelse.fellesdomene.Næringstype
 import no.nav.brukerdialog.ytelse.fellesdomene.Virksomhet
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.*
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.arbeid.*
-import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kursholder
 import java.net.URI
 import java.time.Duration
 import java.time.LocalDate
@@ -159,7 +158,7 @@ class SøknadUtils {
                 )
             ),
             kurs = Kurs(
-                kursholder = Kursholder(
+                kursholder = KursholderType.Kursholder(
                     UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
                     "Senter for Kurs AS"
                 ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
@@ -6,6 +6,7 @@ import no.nav.brukerdialog.ytelse.fellesdomene.Næringstype
 import no.nav.brukerdialog.ytelse.fellesdomene.Virksomhet
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.*
 import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.arbeid.*
+import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.Kursholder
 import java.net.URI
 import java.time.Duration
 import java.time.LocalDate
@@ -158,7 +159,7 @@ class SøknadUtils {
                 )
             ),
             kurs = Kurs(
-                kursholder = KursholderType.Kursholder(
+                kursholder = Kursholder(
                     UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
                     "Senter for Kurs AS"
                 ),


### PR DESCRIPTION
### **Behov / Bakgrunn**
Frontenden for søknaden henter nå institusjonene fra k9-sak. Dersom man velger en av de eksisterende institusjonene skal vi sende med id-en videre inn i søknaden. 

### **Løsning**
Oppdaterer dto-en mot frontend for å ta imot uuid og mapper ut til k9-format.

