### PR TITLE
UNG - Legger til info om barn og kontonummer i søknads-pdf.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ repositories {
 
 val tokenSupportVersion = "5.0.24"
 val jsonassertVersion = "1.5.3"
-val k9FormatVersion = "11.5.0"
+val k9FormatVersion = "12.0.0"
 val ungDeltakelseOpplyserVersjon = "1.3.0"
 val springMockkVersion = "4.0.2"
 val logstashLogbackEncoderVersion = "8.0"

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseService.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseService.kt
@@ -4,6 +4,7 @@ import no.nav.brukerdialog.common.MetaInfo
 import no.nav.brukerdialog.common.formaterStatuslogging
 import no.nav.brukerdialog.domenetjenester.innsending.DuplikatInnsendingSjekker
 import no.nav.brukerdialog.domenetjenester.innsending.InnsendingService
+import no.nav.brukerdialog.integrasjon.k9selvbetjeningoppslag.BarnService
 import no.nav.brukerdialog.integrasjon.ungdeltakelseopplyser.UngDeltakelseOpplyserService
 import no.nav.brukerdialog.metrikk.MetrikkService
 import no.nav.brukerdialog.utils.MDCUtil
@@ -11,6 +12,7 @@ import no.nav.brukerdialog.utils.TokenUtils.personIdent
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering.UngdomsytelseInntektsrapportering
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgavebekreftelseInnsending
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgavebekreftelse
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Barn
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Ungdomsytelsesøknad
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.slf4j.LoggerFactory
@@ -23,7 +25,8 @@ class UngdomsytelseService(
     private val duplikatInnsendingSjekker: DuplikatInnsendingSjekker,
     private val springTokenValidationContextHolder: SpringTokenValidationContextHolder,
     private val metrikkService: MetrikkService,
-    private val ungDeltakelseOpplyserService: UngDeltakelseOpplyserService
+    private val ungDeltakelseOpplyserService: UngDeltakelseOpplyserService,
+    private val barnService: BarnService
 ) {
     private companion object {
         private val logger = LoggerFactory.getLogger(UngdomsytelseService::class.java)
@@ -35,6 +38,11 @@ class UngdomsytelseService(
 
         logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId(), "mottatt."))
         duplikatInnsendingSjekker.forsikreIkkeDuplikatInnsending(cacheKey)
+
+        val barn = barnService.hentBarn().map { Barn(navn = it.navn()) }
+
+        søknad.barn = barn
+
         innsendingService.registrer(søknad, metadata)
         metrikkService.registrerMottattInnsending(søknad.ytelse())
     }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse
 import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse
-import no.nav.k9.oppgave.bekreftelse.ung.inntekt.OppgittInntektForPeriode
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretProgramperiodeBekreftelse
 import no.nav.k9.søknad.felles.type.Periode
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
@@ -72,7 +71,6 @@ data class KomplettKontrollerRegisterInntektOppgaveTypeDataDTO(
     override fun somK9Format(): Bekreftelse {
         val inntektBekreftelse = InntektBekreftelse.builder()
             .medOppgaveReferanse(UUID.fromString(oppgaveReferanse))
-            .medOppgittePeriodeinntekter(registerinntekt.somK9Format())
             .medHarBrukerGodtattEndringen(uttalelse.bekreftelseSvar.somBoolean())
 
         if (!uttalelse.meldingFraDeltaker.isNullOrBlank()) {
@@ -91,18 +89,4 @@ data class KomplettKontrollerRegisterInntektOppgaveTypeDataDTO(
             uttalelse = uttalelse
         )
     }
-
-    private fun RegisterinntektDTO.somK9Format(): MutableSet<OppgittInntektForPeriode> =
-        mutableSetOf<OppgittInntektForPeriode>().apply {
-            addAll(arbeidOgFrilansInntekter.map {
-                OppgittInntektForPeriode.builder(Periode(fraOgMed, tilOgMed))
-                    .medArbeidstakerOgFrilansinntekt(BigDecimal.valueOf(it.inntekt.toLong()))
-                    .build()
-            })
-            addAll(ytelseInntekter.map {
-                OppgittInntektForPeriode.builder(Periode(fraOgMed, tilOgMed))
-                    .medYtelse(BigDecimal.valueOf(it.inntekt.toLong()))
-                    .build()
-            })
-        }
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Barn.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Barn.kt
@@ -1,0 +1,3 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad
+
+data class Barn(val navn: String)

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelseKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelseKomplettSøknad.kt
@@ -1,6 +1,7 @@
 package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad
 
 import no.nav.brukerdialog.domenetjenester.innsending.KomplettInnsending
+import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.oppslag.soker.Søker
 import no.nav.k9.søknad.Søknad
 import java.time.LocalDate
@@ -12,6 +13,10 @@ data class UngdomsytelseKomplettSøknad(
     private val språk: String,
     private val startdato: LocalDate,
     private val mottatt: ZonedDateTime,
+    private val barn: List<Barn>,
+    private val barnErRiktig: Boolean,
+    private val kontonummerFraRegister: String? = null,
+    private val kontonummerErRiktig: Boolean,
     private val harForståttRettigheterOgPlikter: Boolean,
     private val harBekreftetOpplysninger: Boolean,
     private val k9Format: Søknad,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelseKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelseKomplettSøknad.kt
@@ -1,7 +1,6 @@
 package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad
 
 import no.nav.brukerdialog.domenetjenester.innsending.KomplettInnsending
-import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.oppslag.soker.Søker
 import no.nav.k9.søknad.Søknad
 import java.time.LocalDate
@@ -16,7 +15,7 @@ data class UngdomsytelseKomplettSøknad(
     private val barn: List<Barn>,
     private val barnErRiktig: Boolean,
     private val kontonummerFraRegister: String?,
-    private val kontonummerErRiktig: Boolean,
+    private val kontonummerErRiktig: Boolean?,
     private val harForståttRettigheterOgPlikter: Boolean,
     private val harBekreftetOpplysninger: Boolean,
     private val k9Format: Søknad,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelseKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelseKomplettSøknad.kt
@@ -15,7 +15,7 @@ data class UngdomsytelseKomplettSøknad(
     private val mottatt: ZonedDateTime,
     private val barn: List<Barn>,
     private val barnErRiktig: Boolean,
-    private val kontonummerFraRegister: String? = null,
+    private val kontonummerFraRegister: String?,
     private val kontonummerErRiktig: Boolean,
     private val harForståttRettigheterOgPlikter: Boolean,
     private val harBekreftetOpplysninger: Boolean,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
@@ -1,10 +1,10 @@
 package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad
 
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.AssertTrue
 import no.nav.brukerdialog.common.MetaInfo
 import no.nav.brukerdialog.domenetjenester.innsending.Innsending
-import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.oppslag.soker.Søker
 import no.nav.brukerdialog.ytelse.Ytelse
 import no.nav.k9.søknad.Søknad
@@ -35,13 +35,14 @@ data class Ungdomsytelsesøknad(
     val startdato: LocalDate,
     val søkerNorskIdent: String,
 
-    var barn: List<Barn>, // Settes i UngdomsytelseService.
+    @Hidden
+    var barn: List<Barn>? = null, // Settes i UngdomsytelseService.
     @field:AssertTrue(message = "Må bekrefte at opplysningene om barn er riktige for å sende inn søknad")
     val barnErRiktig: Boolean,
 
     val kontonummerFraRegister: String? = null,
     @field:AssertTrue(message = "Må bekrefte at kontonummeret er riktig for å sende inn søknad")
-    val kontonummerErRiktig: Boolean,
+    val kontonummerErRiktig: Boolean? = null,
 
     @field:AssertTrue(message = "Opplysningene må bekreftes for å sende inn søknad")
     val harBekreftetOpplysninger: Boolean,
@@ -66,7 +67,7 @@ data class Ungdomsytelsesøknad(
             søker = søker,
             språk = språk,
             startdato = startdato,
-            barn = barn,
+            barn = barn!!,
             barnErRiktig = barnErRiktig,
             kontonummerFraRegister = kontonummerFraRegister,
             kontonummerErRiktig = kontonummerErRiktig,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
@@ -55,6 +55,12 @@ data class Ungdomsytelsesøknad(
         private val SØKNAD_TYPE = UngSøknadstype.DELTAKELSE_SØKNAD
     }
 
+    @Hidden
+    @AssertTrue(message = "Dersom kontonummerFraRegister er satt, må kontonummerErRiktig være satt")
+    fun isKontonummerErRiktig(): Boolean = if (!kontonummerFraRegister.isNullOrBlank()) {
+        kontonummerErRiktig !== null
+    } else true
+
     override fun somKomplettSøknad(
         søker: Søker,
         k9Format: no.nav.k9.søknad.Innsending?,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.AssertTrue
 import no.nav.brukerdialog.common.MetaInfo
 import no.nav.brukerdialog.domenetjenester.innsending.Innsending
+import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.oppslag.soker.Søker
 import no.nav.brukerdialog.ytelse.Ytelse
 import no.nav.k9.søknad.Søknad
@@ -34,9 +35,16 @@ data class Ungdomsytelsesøknad(
     val startdato: LocalDate,
     val søkerNorskIdent: String,
 
+    var barn: List<Barn>, // Settes i UngdomsytelseService.
+    @field:AssertTrue(message = "Må bekrefte at opplysningene om barn er riktige for å sende inn søknad")
+    val barnErRiktig: Boolean,
+
+    val kontonummerFraRegister: String? = null,
+    @field:AssertTrue(message = "Må bekrefte at kontonummeret er riktig for å sende inn søknad")
+    val kontonummerErRiktig: Boolean,
+
     @field:AssertTrue(message = "Opplysningene må bekreftes for å sende inn søknad")
     val harBekreftetOpplysninger: Boolean,
-
     @field:AssertTrue(message = "Må ha forstått rettigheter og plikter for å sende inn søknad")
     val harForståttRettigheterOgPlikter: Boolean,
 
@@ -58,6 +66,10 @@ data class Ungdomsytelsesøknad(
             søker = søker,
             språk = språk,
             startdato = startdato,
+            barn = barn,
+            barnErRiktig = barnErRiktig,
+            kontonummerFraRegister = kontonummerFraRegister,
+            kontonummerErRiktig = kontonummerErRiktig,
             harForståttRettigheterOgPlikter = harForståttRettigheterOgPlikter,
             harBekreftetOpplysninger = harBekreftetOpplysninger,
             k9Format = k9Format as UngSøknad

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/soknad/domene/UngdomsytelsesøknadMottatt.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/soknad/domene/UngdomsytelsesøknadMottatt.kt
@@ -3,8 +3,10 @@ package no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.soknad.domene
 import no.nav.brukerdialog.common.Ytelse
 import no.nav.brukerdialog.domenetjenester.mottak.MottattMelding
 import no.nav.brukerdialog.domenetjenester.mottak.PreprosesseringsData
+import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.ytelse.fellesdomene.Søker
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Barn
 import no.nav.brukerdialog.ytelse.ungdomsytelse.pdf.UngdomsytelsesøknadPdfData
 import no.nav.k9.søknad.Søknad
 import java.time.LocalDate
@@ -16,6 +18,10 @@ data class UngdomsytelsesøknadMottatt(
     val språk: String? = "nb",
     val søker: Søker,
     val startdato: LocalDate? = null,
+    val barn: List<Barn>,
+    val barnErRiktig: Boolean,
+    val kontonummerFraRegister: String? = null,
+    val kontonummerErRiktig: Boolean,
     val k9Format: Søknad,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/soknad/domene/UngdomsytelsesøknadMottatt.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/soknad/domene/UngdomsytelsesøknadMottatt.kt
@@ -21,7 +21,7 @@ data class UngdomsytelsesøknadMottatt(
     val barn: List<Barn>,
     val barnErRiktig: Boolean,
     val kontonummerFraRegister: String? = null,
-    val kontonummerErRiktig: Boolean,
+    val kontonummerErRiktig: Boolean? = null,
     val k9Format: Søknad,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/soknad/domene/UngdomsytelsesøknadPreprosessertSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/soknad/domene/UngdomsytelsesøknadPreprosessertSøknad.kt
@@ -6,8 +6,10 @@ import no.nav.brukerdialog.dittnavvarsel.K9Beskjed
 import no.nav.brukerdialog.domenetjenester.mottak.JournalføringsService
 import no.nav.brukerdialog.domenetjenester.mottak.Preprosessert
 import no.nav.brukerdialog.integrasjon.dokarkiv.dto.YtelseType
+import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.ytelse.fellesdomene.Navn
 import no.nav.brukerdialog.ytelse.fellesdomene.Søker
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Barn
 import no.nav.k9.søknad.Søknad
 import java.time.LocalDate
 import java.time.ZonedDateTime
@@ -20,6 +22,10 @@ data class UngdomsytelsesøknadPreprosessertSøknad(
     val språk: String?,
     val søker: Søker,
     val startdato: LocalDate? = null,
+    val barn: List<Barn>,
+    val barnErRiktig: Boolean,
+    val kontonummerFraRegister: String? = null,
+    val kontonummerErRiktig: Boolean,
     val dokumentId: List<List<String>>,
     val k9Format: K9Søknad,
     val harForståttRettigheterOgPlikter: Boolean,
@@ -34,6 +40,10 @@ data class UngdomsytelsesøknadPreprosessertSøknad(
         mottatt = ungdomsytelseSøknadMottatt.mottatt,
         søker = ungdomsytelseSøknadMottatt.søker,
         startdato = ungdomsytelseSøknadMottatt.startdato,
+        barn = ungdomsytelseSøknadMottatt.barn,
+        barnErRiktig = ungdomsytelseSøknadMottatt.barnErRiktig,
+        kontonummerFraRegister = ungdomsytelseSøknadMottatt.kontonummerFraRegister,
+        kontonummerErRiktig = ungdomsytelseSøknadMottatt.kontonummerErRiktig,
         dokumentId = dokumentId,
         k9Format = ungdomsytelseSøknadMottatt.k9Format,
         harForståttRettigheterOgPlikter = ungdomsytelseSøknadMottatt.harForståttRettigheterOgPlikter,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/soknad/domene/UngdomsytelsesøknadPreprosessertSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/soknad/domene/UngdomsytelsesøknadPreprosessertSøknad.kt
@@ -6,7 +6,6 @@ import no.nav.brukerdialog.dittnavvarsel.K9Beskjed
 import no.nav.brukerdialog.domenetjenester.mottak.JournalføringsService
 import no.nav.brukerdialog.domenetjenester.mottak.Preprosessert
 import no.nav.brukerdialog.integrasjon.dokarkiv.dto.YtelseType
-import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.ytelse.fellesdomene.Navn
 import no.nav.brukerdialog.ytelse.fellesdomene.Søker
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Barn
@@ -25,7 +24,7 @@ data class UngdomsytelsesøknadPreprosessertSøknad(
     val barn: List<Barn>,
     val barnErRiktig: Boolean,
     val kontonummerFraRegister: String? = null,
-    val kontonummerErRiktig: Boolean,
+    val kontonummerErRiktig: Boolean? = null,
     val dokumentId: List<List<String>>,
     val k9Format: K9Søknad,
     val harForståttRettigheterOgPlikter: Boolean,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
@@ -4,9 +4,11 @@ import no.nav.brukerdialog.common.Constants.DATE_FORMATTER
 import no.nav.brukerdialog.common.Constants.DATE_TIME_FORMATTER
 import no.nav.brukerdialog.common.Constants.OSLO_ZONE_ID
 import no.nav.brukerdialog.common.Ytelse
+import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.pdf.PdfData
 import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Barn
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.soknad.domene.UngdomsytelsesøknadMottatt
 import no.nav.k9.søknad.felles.type.Språk
 
@@ -22,12 +24,26 @@ class UngdomsytelsesøknadPdfData(private val søknad: UngdomsytelsesøknadMotta
         "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
         "startdato" to søknad.startdato?.let { DATE_FORMATTER.format(it) },
         "søker" to søknad.søker.somMap(),
+        "barn" to mapOf(
+            "barnErRiktig" to søknad.barnErRiktig,
+            "folkeregistrerteBarn" to if (søknad.barn.isNotEmpty()) {
+                søknad.barn.map { it.somMap() }
+            } else null,
+        ),
+        "kontonummer" to mapOf(
+            "kontonummerErRiktig" to søknad.kontonummerErRiktig,
+            "kontonummerFraRegister" to søknad.kontonummerFraRegister
+        ),
         "samtykke" to mapOf(
             "harForståttRettigheterOgPlikter" to søknad.harForståttRettigheterOgPlikter,
             "harBekreftetOpplysninger" to søknad.harBekreftetOpplysninger
         ),
         "hjelp" to mapOf(
-            "språk" to søknad.språk?.språkTilTekst()
+            "språk" to søknad.språk?.språkTilTekst(),
         )
+    )
+
+    private fun Barn.somMap(): Map<String, String?> = mapOf(
+        "navn" to navn
     )
 }

--- a/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
@@ -53,7 +53,7 @@
                 {{/each}}
             </ul>
 
-            <p class="sporsmalstekst">Stemmer informasjon på barn(a)?</p>
+            <p class="sporsmalstekst">Stemmer informasjon om barn(a)?</p>
             <p>{{ jaNeiSvar barn.barnErRiktig }}</p>
         {{else}}
             <p>Vi har ikke registrert at du har barn.</p>

--- a/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
@@ -11,6 +11,8 @@
     <bookmarks>
         <bookmark name="Søker" href="#søker"/>
         <bookmark name="Startdato" href="#startdato"/>
+        <bookmark name="Kontonummer" href="#kontonummer"/>
+        <bookmark name="Barn" href="#barn"/>
         <bookmark name="Samtykke" href="#samtykke"/>
     </bookmarks>
     {{#block 'style-common' }}
@@ -29,6 +31,37 @@
     <section id="periode">
         <h2>Deltar i ungdomsprogrammet:</h2>
         <p><strong>Fra og med:</strong> {{startdato}}</p>
+    </section>
+
+    <section id="kontonummer">
+        <h2>Kontonummer for utbetaling</h2>
+        {{#if kontonummer.kontonummerFraRegister}}
+            <p class="sporsmalstekst">Stemmer det at kontonummeret ditt er {{kontonummer.kontonummerFraRegister}}?</p>
+            <p>{{ jaNeiSvar kontonummer.kontonummerErRiktig }}</p>
+        {{else}}
+            <p>Vi har ikke registrert kontonummer på deg.</p>
+        {{/if}}
+    </section>
+
+    <section id="barn">
+        <h2>Barn</h2>
+        <p class="sporsmalstekst">Barn vi har registrert på deg:</p>
+        {{#if barn.folkeregistrerteBarn}}
+            <ul>
+                {{#each barn.folkeregistrerteBarn as |dineBarn|}}
+                    <li>{{dineBarn.navn}}</li>
+                {{/each}}
+            </ul>
+
+            <p class="sporsmalstekst">Stemmer informasjon på barn(a)?</p>
+            <p>{{ jaNeiSvar barn.barnErRiktig }}</p>
+        {{else}}
+            <p>Vi har ikke registrert at du har barn.</p>
+
+            <br/>
+            <p class="sporsmalstekst">Stemmer det at du ikke har barn?</p>
+            <p>{{ jaNeiSvar barn.barnErRiktig }}</p>
+        {{/if}}
     </section>
 
     <!-- SAMTYKKE -->

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseControllerTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseControllerTest.kt
@@ -90,7 +90,7 @@ class UngdomsytelseControllerTest {
         coEvery { innsendingService.registrer(any(), any()) } returns Unit
         every { metrikkService.registrerMottattInnsending(any()) } returns Unit
 
-        val defaultSøknad = SøknadUtils.defaultSøknad
+        val defaultSøknad = SøknadUtils.defaultSøknad.copy(barn = listOf())
 
         mockMvc.post("/ungdomsytelse/soknad/innsending") {
             headers {
@@ -135,6 +135,9 @@ class UngdomsytelseControllerTest {
 
         val jsonPayload = objectMapper.writeValueAsString(
             defaultSøknad.copy(
+                barn = listOf(),
+                barnErRiktig = false,
+                kontonummerErRiktig = false,
                 harForståttRettigheterOgPlikter = false,
                 harBekreftetOpplysninger = false,
             )
@@ -171,6 +174,18 @@ class UngdomsytelseControllerTest {
                               "parameterName": "ungdomsytelsesøknad.harBekreftetOpplysninger",
                               "parameterType": "ENTITY",
                               "reason": "Opplysningene må bekreftes for å sende inn søknad"
+                            },
+                            {
+                              "invalidValue": false,
+                              "parameterName": "ungdomsytelsesøknad.barnErRiktig",
+                              "parameterType": "ENTITY",
+                              "reason": "Må bekrefte at opplysningene om barn er riktige for å sende inn søknad"
+                            },
+                            {
+                              "invalidValue": false,
+                              "parameterName": "ungdomsytelsesøknad.kontonummerErRiktig",
+                              "parameterType": "ENTITY",
+                              "reason": "Må bekrefte at kontonummeret er riktig for å sende inn søknad"
                             },
                           ]
                         }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadKonsumentTest.kt
@@ -113,6 +113,14 @@ class UngdomsytelsesøknadKonsumentTest : AbstractIntegrationTest() {
             "fødselsnummer": "02119970078"
           },
           "startdato": "2022-01-01",
+          "barn": [
+            {
+              "navn": "Ola Nordmann"
+            }
+          ],
+          "barnErRiktig": true,
+          "kontonummerFraRegister": "12345678901",
+          "kontonummerErRiktig": true,
           "språk": "nb",
           "harForståttRettigheterOgPlikter": true,
           "dokumentId": [

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelesøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelesøknadPdfGeneratorTest.kt
@@ -34,6 +34,18 @@ class UngdomsytelesøknadPdfGeneratorTest {
             var id = "1-full-søknad"
             var pdf = generator.genererPDF(UngdomsytelsesøknadUtils.gyldigSøknad(søknadId = id).pdfData())
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+            id = "2-uten-barn"
+            pdf = generator.genererPDF(UngdomsytelsesøknadUtils.gyldigSøknad(søknadId = id)
+                .copy(barn = emptyList(), barnErRiktig = false)
+                .pdfData())
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+            id = "3-uten-kontonummer"
+            pdf = generator.genererPDF(UngdomsytelsesøknadUtils.gyldigSøknad(søknadId = id)
+                .copy(kontonummerFraRegister = null, kontonummerErRiktig = false)
+                .pdfData())
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
         }
     }
 }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelesøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelesøknadPdfGeneratorTest.kt
@@ -35,13 +35,13 @@ class UngdomsytelesøknadPdfGeneratorTest {
             var pdf = generator.genererPDF(UngdomsytelsesøknadUtils.gyldigSøknad(søknadId = id).pdfData())
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
 
-            id = "2-uten-barn"
+            id = "2-søknad-uten-barn"
             pdf = generator.genererPDF(UngdomsytelsesøknadUtils.gyldigSøknad(søknadId = id)
                 .copy(barn = emptyList(), barnErRiktig = false)
                 .pdfData())
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
 
-            id = "3-uten-kontonummer"
+            id = "3-søknad-uten-kontonummer"
             pdf = generator.genererPDF(UngdomsytelsesøknadUtils.gyldigSøknad(søknadId = id)
                 .copy(kontonummerFraRegister = null, kontonummerErRiktig = false)
                 .pdfData())

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/SøknadUtils.kt
@@ -1,10 +1,12 @@
 package no.nav.brukerdialog.ytelse.ungdomsytelse.utils
 
 import no.nav.brukerdialog.config.JacksonConfiguration
+import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.BekreftelseSvar
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveUttalelseDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgavebekreftelse
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Barn
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Ungdomsytelsesøknad
 import java.time.LocalDate
 import java.time.ZonedDateTime
@@ -17,6 +19,12 @@ object SøknadUtils {
         språk = "nb",
         søkerNorskIdent = "12345678910",
         startdato = LocalDate.parse("2021-01-01"),
+        barn = listOf(
+            Barn(navn = "Ola Nordmann")
+        ),
+        barnErRiktig = true,
+        kontonummerFraRegister = "12345678901",
+        kontonummerErRiktig = true,
         harForståttRettigheterOgPlikter = true,
         harBekreftetOpplysninger = true
     )

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
@@ -1,6 +1,8 @@
 package no.nav.brukerdialog.ytelse.ungdomsytelse.utils
 
+import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.ytelse.fellesdomene.Søker
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Barn
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.soknad.domene.UngdomsytelsesøknadMottatt
 import no.nav.k9.søknad.felles.Kildesystem
 import no.nav.k9.søknad.felles.Versjon
@@ -37,6 +39,14 @@ object UngdomsytelsesøknadUtils {
                 fornavn = "Ola"
             ),
             startdato = startdato,
+            barn = listOf(
+                Barn(
+                    navn = "Ola Nordmann"
+                )
+            ),
+            barnErRiktig = true,
+            kontonummerFraRegister = "12345678901",
+            kontonummerErRiktig = true,
             k9Format = gyldigK9Format(søknadId, mottatt, startdato),
             harBekreftetOpplysninger = true,
             harForståttRettigheterOgPlikter = true


### PR DESCRIPTION
### **Behov / Bakgrunn**
Deltaker får spørsmål om å bekrefte at opplysninger om barn og kontonummer er riktige i søknaden.

### **Løsning**
Legger til støtte for å kunne motta og legge til i pdf-en for søknaden.

### **Skjermbilder** (hvis relevant)
#### Søknad med barn og kontonummer
![image](https://github.com/user-attachments/assets/ff589758-1c4b-40b9-b917-cf3f9b98f480)

#### Søknad uten barn
![image](https://github.com/user-attachments/assets/621eafda-6807-4db6-ade7-331f985402fc)

#### Søknad uten kontonummer
![image](https://github.com/user-attachments/assets/ae1d7ba4-0389-4ae4-a8d9-5e43af40041b)

