### PR TITLE
TSFF-1488: Utled søknadsperioder og uttaksperioder fra kursperioder

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/OpplæringspengerSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/OpplæringspengerSøknad.kt
@@ -165,7 +165,7 @@ data class OpplæringspengerSøknad(
     override fun søknadValidator(): SøknadValidator<no.nav.k9.søknad.Søknad> = OpplæringspengerSøknadValidator()
 
     override fun somK9Format(søker: Søker, metadata: MetaInfo): no.nav.k9.søknad.Innsending {
-        val søknadsperiode = K9Periode(fraOgMed, tilOgMed)
+        val søknadsperiode = kurs.kursperioder
         val olp = Opplæringspenger()
             .medSøknadsperiode(søknadsperiode)
             .medBarn(barn.tilK9Barn())
@@ -173,6 +173,7 @@ data class OpplæringspengerSøknad(
             .medArbeidstid(byggK9Arbeidstid())
             .medUttak(byggK9Uttak(søknadsperiode))
             .medBosteder(medlemskap.tilK9Bosteder())
+            .medKurs(kurs.tilK9Format())
             .medDataBruktTilUtledning(byggK9DataBruktTilUtledning(metadata)) as Opplæringspenger
 
         barn.relasjonTilBarnet?.let { olp.medOmsorg(byggK9Omsorg()) }
@@ -183,19 +184,19 @@ data class OpplæringspengerSøknad(
             }
         }
 
-        olp.medKurs(kurs.tilK9Format())
-
         return K9Søknad(SøknadId.of(søknadId), k9FormatVersjon, mottatt, søker.somK9Søker(), olp)
             .medKildesystem(Kildesystem.SØKNADSDIALOG)
             .medSpråk(K9Språk.of(språk.name))
     }
 
-    fun byggK9Uttak(periode: K9Periode): Uttak {
-        val perioder = mutableMapOf<K9Periode, Uttak.UttakPeriodeInfo>()
+    fun byggK9Uttak(perioder: List<K9Periode>): Uttak {
+        val uttaksPerioder = mutableMapOf<K9Periode, Uttak.UttakPeriodeInfo>()
 
-        perioder[periode] = Uttak.UttakPeriodeInfo(Duration.ofHours(7).plusMinutes(30))
+        perioder.forEach { periode ->
+            uttaksPerioder[periode] = Uttak.UttakPeriodeInfo(Duration.ofHours(7).plusMinutes(30))
+        }
 
-        return Uttak().medPerioder(perioder)
+        return Uttak().medPerioder(uttaksPerioder)
     }
 
     private fun byggK9OpptjeningAktivitet() = OpptjeningAktivitet().apply {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/K9FormatTest.kt
@@ -194,9 +194,9 @@ class K9FormatTest {
                   "institusjonsidentifikator" : "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
                   "navn" : "Senter for Kurs AS"
                 },
-                "kursperioder" : [ "2022-01-01/2022-01-10" ],
+                "kursperioder" : [ "2021-01-01/2021-01-10" ],
                 "reise" : {
-                  "reisedager" : [ "2022-01-01", "2022-01-10" ],
+                  "reisedager" : [ "2021-01-01", "2021-01-10" ],
                   "reisedagerBeskrivelse" : "Reise til kurs tok mer enn en dag",
                   "reiserUtenforKursdager" : true
                 }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
@@ -110,7 +110,7 @@ class SøknadUtils {
             ),
             vedlegg = listOf(URI.create("http://localhost:8080/vedlegg/1").toURL()),
             fraOgMed = LocalDate.parse("2021-01-01"),
-            tilOgMed = LocalDate.parse("2021-10-01"),
+            tilOgMed = LocalDate.parse("2021-01-10"),
             medlemskap = Medlemskap(
                 harBoddIUtlandetSiste12Mnd = true,
                 skalBoIUtlandetNeste12Mnd = true,
@@ -165,15 +165,15 @@ class SøknadUtils {
                 ),
                 kursperioder = listOf(
                     K9Periode(
-                        LocalDate.parse("2022-01-01"),
-                        LocalDate.parse("2022-01-10")
+                        LocalDate.parse("2021-01-01"),
+                        LocalDate.parse("2021-01-10")
                     )
                 ),
                 reise = Reise(
                     reiserUtenforKursdager = true,
                     reisedager = listOf(
-                        LocalDate.parse("2022-01-01"),
-                        LocalDate.parse("2022-01-10")
+                        LocalDate.parse("2021-01-01"),
+                        LocalDate.parse("2021-01-10")
                     ),
                     reisedagerBeskrivelse = "Reise til kurs tok mer enn en dag"
                 )


### PR DESCRIPTION
### **Behov / Bakgrunn**
Søknadsperioder og uttaksperioder speiler ikke det man har lagt inn i kursperioder. Det blir feil i k9-sak.

Jira: https://jira.adeo.no/browse/TSFF-1488

### **Løsning**
Utleder søknadsperioder og uttaksperioder fra kursperioder. 