### PR TITLE
UNG - Bruker oppgaveReferanse på inntektsrapportering.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ repositories {
 val tokenSupportVersion = "5.0.25"
 val jsonassertVersion = "1.5.3"
 val k9FormatVersion = "12.2.0"
-val ungDeltakelseOpplyserVersjon = "1.5.0"
+val ungDeltakelseOpplyserVersjon = "1.7.0"
 val springMockkVersion = "4.0.2"
 val logstashLogbackEncoderVersion = "8.1"
 val slf4jVersion = "2.0.17"

--- a/src/main/kotlin/no/nav/brukerdialog/domenetjenester/innsending/Innsending.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/domenetjenester/innsending/Innsending.kt
@@ -11,7 +11,7 @@ import no.nav.k9.søknad.felles.type.Periode as K9Periode
 interface Innsending {
     fun søkerNorskIdent(): String?
     fun ytelse(): Ytelse
-    fun søknadId(): String
+    fun innsendingId(): String
     fun inneholderVedlegg(): Boolean = vedlegg().isNotEmpty()
     fun vedlegg(): List<URL>
     fun somK9Format(søker: Søker, metadata: MetaInfo): no.nav.k9.søknad.Innsending? = null

--- a/src/main/kotlin/no/nav/brukerdialog/domenetjenester/innsending/KomplettInnsending.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/domenetjenester/innsending/KomplettInnsending.kt
@@ -1,3 +1,5 @@
 package no.nav.brukerdialog.domenetjenester.innsending
 
-interface KomplettInnsending
+interface KomplettInnsending {
+    fun innsendingId(): String
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/Ettersendelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/Ettersendelse.kt
@@ -85,7 +85,7 @@ data class Ettersendelse(
 
     override fun ytelse(): Ytelse = Ytelse.ETTERSENDING
 
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
 
     override fun vedlegg(): List<URL> = vedlegg
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/KomplettEttersendelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/KomplettEttersendelse.kt
@@ -21,6 +21,7 @@ data class KomplettEttersendelse(
     private val ettersendelsesType: EttersendelseType,
     private val pleietrengende: Pleietrengende? = null
 ): KomplettInnsending {
+    override fun innsendingId(): String = søknadId
 
     override fun equals(other: Any?) = this === other || (other is KomplettEttersendelse && this.equals(other))
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/api/domene/OmsorgspengerutbetalingArbeidstakerKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/api/domene/OmsorgspengerutbetalingArbeidstakerKomplettSøknad.kt
@@ -23,4 +23,6 @@ data class OmsorgspengerutbetalingArbeidstakerKomplettSøknad(
     private val hjemmePgaSmittevernhensyn: Boolean,
     private val hjemmePgaStengtBhgSkole: Boolean? = null,
     private val k9Format: Søknad
-): KomplettInnsending
+): KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/api/domene/OmsorgspengerutbetalingArbeidstakerSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingat/api/domene/OmsorgspengerutbetalingArbeidstakerSøknad.kt
@@ -129,6 +129,6 @@ data class OmsorgspengerutbetalingArbeidstakerSøknad(
     override fun søkerNorskIdent(): String? = søkerNorskIdent
 
     override fun ytelse(): Ytelse = Ytelse.OMSORGSPENGER_UTBETALING_ARBEIDSTAKER
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
     override fun vedlegg(): List<URL> = vedlegg
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/api/domene/OmsorgspengerutbetalingSnfKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/api/domene/OmsorgspengerutbetalingSnfKomplettSøknad.kt
@@ -33,4 +33,6 @@ data class OmsorgspengerutbetalingSnfKomplettSøknad(
     private val vedleggId: List<String> = listOf(),
     private val titler: List<String>,
     private val k9FormatSøknad: Søknad,
-) : KomplettInnsending
+) : KomplettInnsending {
+    override fun innsendingId(): String = søknadId.id
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/api/domene/OmsorgspengerutbetalingSnfSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgpengerutbetalingsnf/api/domene/OmsorgspengerutbetalingSnfSøknad.kt
@@ -131,7 +131,7 @@ data class OmsorgspengerutbetalingSnfSøknad(
     override fun søkerNorskIdent(): String? = søkerNorskIdent
 
     override fun ytelse(): Ytelse = Ytelse.OMSORGSPENGER_UTBETALING_SNF
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
     override fun vedlegg(): List<URL> = vedlegg
     override fun søknadValidator(): SøknadValidator<no.nav.k9.søknad.Søknad> = OmsorgspengerUtbetalingSøknadValidator()
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneOmOmsorgenKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneOmOmsorgenKomplettSøknad.kt
@@ -14,4 +14,6 @@ data class OmsorgsdagerAleneOmOmsorgenKomplettSøknad(
     private val k9Søknad: Søknad,
     private val harForståttRettigheterOgPlikter: Boolean,
     private val harBekreftetOpplysninger: Boolean
-): KomplettInnsending
+): KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneOmOmsorgenSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneOmOmsorgenSøknad.kt
@@ -115,7 +115,7 @@ data class OmsorgsdagerAleneOmOmsorgenSøknad(
     override fun søkerNorskIdent(): String? = søkerNorskIdent
 
     override fun ytelse(): Ytelse = Ytelse.OMSORGSDAGER_ALENEOMSORG
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
     override fun vedlegg(): List<URL> = listOf()
 
     override fun søknadValidator(): SøknadValidator<Søknad> = OmsorgspengerAleneOmsorgSøknadValidator()

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerKroniskSyktBarnKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerKroniskSyktBarnKomplettSøknad.kt
@@ -24,4 +24,6 @@ data class OmsorgspengerKroniskSyktBarnKomplettSøknad(
     private val harBekreftetOpplysninger: Boolean,
     private val høyereRisikoForFravær: Boolean?,
     private val høyereRisikoForFraværBeskrivelse: String?
-): KomplettInnsending
+): KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerKroniskSyktBarnSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerKroniskSyktBarnSøknad.kt
@@ -134,7 +134,7 @@ data class OmsorgspengerKroniskSyktBarnSøknad(
     override fun søkerNorskIdent(): String? = søkerNorskIdent
 
     override fun ytelse(): Ytelse = Ytelse.OMSORGSPENGER_UTVIDET_RETT
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
     override fun vedlegg(): List<URL> = mutableListOf<URL>().apply {
         addAll(legeerklæring)
         samværsavtale?.let { addAll(it) }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMdlertidigAleneKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMdlertidigAleneKomplettSøknad.kt
@@ -17,4 +17,6 @@ data class OmsorgspengerMdlertidigAleneKomplettSøknad(
     val k9Format: Søknad,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean
-): KomplettInnsending
+): KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMidlertidigAleneSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMidlertidigAleneSøknad.kt
@@ -105,7 +105,7 @@ data class OmsorgspengerMidlertidigAleneSøknad(
     override fun søkerNorskIdent(): String? = søkerNorskIdent
 
     override fun ytelse(): Ytelse = Ytelse.OMSORGSPENGER_MIDLERTIDIG_ALENE
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
     override fun vedlegg(): List<URL> = listOf()
     override fun søknadValidator(): SøknadValidator<no.nav.k9.søknad.Søknad> =
         OmsorgspengerMidlertidigAleneSøknadValidator()

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/KomplettOpplæringspengerSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/KomplettOpplæringspengerSøknad.kt
@@ -34,6 +34,8 @@ data class KomplettOpplæringspengerSøknad(
     val kurs: Kurs,
     val k9FormatSøknad: Søknad? = null,
 ) : KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/OpplæringspengerSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/OpplæringspengerSøknad.kt
@@ -141,7 +141,7 @@ data class OpplæringspengerSøknad(
 
     override fun ytelse(): Ytelse = Ytelse.OPPLARINGSPENGER
 
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
 
     override fun vedlegg(): List<URL> = mutableListOf<URL>().apply {
         addAll(vedlegg)

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/api/domene/PilsKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/api/domene/PilsKomplettSøknad.kt
@@ -31,4 +31,6 @@ data class PilsKomplettSøknad(
     private val harBekreftetOpplysninger: Boolean,
     private val flereSokere: FlereSokereSvar? = null,
     private val k9Format: K9Søknad
-): KomplettInnsending
+): KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/api/domene/PleiepengerILivetsSluttfaseSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetsslutttfase/api/domene/PleiepengerILivetsSluttfaseSøknad.kt
@@ -182,7 +182,7 @@ data class PleiepengerILivetsSluttfaseSøknad(
 
     override fun ytelse(): Ytelse = Ytelse.PLEIEPENGER_LIVETS_SLUTTFASE
 
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
     override fun vedlegg(): List<URL> = mutableListOf<URL>().apply {
         addAll(vedleggUrls)
         addAll(opplastetIdVedleggUrls)

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/api/domene/Endringsmelding.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/api/domene/Endringsmelding.kt
@@ -48,7 +48,7 @@ data class Endringsmelding(
 
     override fun ytelse(): Ytelse = Ytelse.ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN
 
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
 
     override fun vedlegg(): List<URL> = listOf()
 
@@ -92,4 +92,6 @@ data class KomplettEndringsmelding(
     val harForståttRettigheterOgPlikter: Boolean,
     val k9Format: Søknad,
     val pleietrengendeNavn: String,
-) : KomplettInnsending
+) : KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/KomplettPleiepengerSyktBarnSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/KomplettPleiepengerSyktBarnSøknad.kt
@@ -44,6 +44,8 @@ data class KomplettPleiepengerSyktBarnSøknad(
     val harVærtEllerErVernepliktig: Boolean? = null,
     val k9FormatSøknad: Søknad? = null,
 ) : KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/PleiepengerSyktBarnSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/PleiepengerSyktBarnSøknad.kt
@@ -148,7 +148,7 @@ data class PleiepengerSyktBarnSøknad(
 
     override fun ytelse(): Ytelse = Ytelse.PLEIEPENGER_SYKT_BARN
 
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
 
     override fun vedlegg(): List<URL> = mutableListOf<URL>().apply {
         addAll(vedlegg)

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseService.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseService.kt
@@ -9,12 +9,16 @@ import no.nav.brukerdialog.integrasjon.ungdeltakelseopplyser.UngDeltakelseOpplys
 import no.nav.brukerdialog.metrikk.MetrikkService
 import no.nav.brukerdialog.utils.MDCUtil
 import no.nav.brukerdialog.utils.TokenUtils.personIdent
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering.OppgittInntektForPeriode
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering.UngPeriode
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering.UngdomsytelseInntektsrapportering
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering.UngdomsytelseInntektsrapporteringInnsending
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgavebekreftelseInnsending
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgavebekreftelse
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Barn
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.soknad.Ungdomsytelsesøknad
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeDataDTO
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.*
@@ -48,13 +52,33 @@ class UngdomsytelseService(
     }
 
     suspend fun inntektrapportering(rapportetInntekt: UngdomsytelseInntektsrapportering, gitSha: String) {
-        val metadata = MetaInfo(correlationId = MDCUtil.callIdOrNew(), soknadDialogCommitSha = gitSha)
-        val cacheKey = "${springTokenValidationContextHolder.personIdent()}_${rapportetInntekt.ytelse()}"
+        val rapporterInntektOppgave = ungDeltakelseOpplyserService.hentOppgaveForDeltakelse(
+            UUID.fromString(rapportetInntekt.oppgaveReferanse)
+        )
 
-        logger.info(formaterStatuslogging(rapportetInntekt.ytelse(), rapportetInntekt.innsendingId(), "mottatt."))
+        val inntektsrapporteringOppgaveData = (rapporterInntektOppgave.oppgavetypeData as? InntektsrapporteringOppgavetypeDataDTO
+            ?: throw IllegalStateException("OppgavetypeData er ikke av type InntektsrapporteringOppgavetypeDataDTO"))
+
+        val inntektsrapporteringInnsending = UngdomsytelseInntektsrapporteringInnsending(
+            oppgaveReferanse = rapportetInntekt.oppgaveReferanse,
+            mottatt = rapportetInntekt.mottatt,
+            oppgittInntektForPeriode = OppgittInntektForPeriode(
+                arbeidstakerOgFrilansInntekt = rapportetInntekt.oppgittInntekt.arbeidstakerOgFrilansInntekt,
+                periodeForInntekt = UngPeriode(
+                    fraOgMed = inntektsrapporteringOppgaveData.fraOgMed,
+                    tilOgMed = inntektsrapporteringOppgaveData.tilOgMed
+                )
+            ),
+            harBekreftetInntekt = rapportetInntekt.harBekreftetInntekt,
+        )
+
+        val metadata = MetaInfo(correlationId = MDCUtil.callIdOrNew(), soknadDialogCommitSha = gitSha)
+        val cacheKey = "${springTokenValidationContextHolder.personIdent()}_${inntektsrapporteringInnsending.ytelse()}"
+
+        logger.info(formaterStatuslogging(inntektsrapporteringInnsending.ytelse(), inntektsrapporteringInnsending.innsendingId(), "mottatt."))
         duplikatInnsendingSjekker.forsikreIkkeDuplikatInnsending(cacheKey)
-        innsendingService.registrer(rapportetInntekt, metadata)
-        metrikkService.registrerMottattInnsending(rapportetInntekt.ytelse())
+        innsendingService.registrer(inntektsrapporteringInnsending, metadata)
+        metrikkService.registrerMottattInnsending(inntektsrapporteringInnsending.ytelse())
     }
 
     suspend fun oppgavebekreftelse(oppgavebekreftelse: UngdomsytelseOppgavebekreftelse, gitSha: String) {

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseService.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseService.kt
@@ -36,7 +36,7 @@ class UngdomsytelseService(
         val metadata = MetaInfo(correlationId = MDCUtil.callIdOrNew(), soknadDialogCommitSha = gitSha)
         val cacheKey = "${springTokenValidationContextHolder.personIdent()}_${søknad.ytelse()}"
 
-        logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId(), "mottatt."))
+        logger.info(formaterStatuslogging(søknad.ytelse(), søknad.innsendingId(), "mottatt."))
         duplikatInnsendingSjekker.forsikreIkkeDuplikatInnsending(cacheKey)
 
         val barn = barnService.hentBarn().map { Barn(navn = it.navn()) }
@@ -51,7 +51,7 @@ class UngdomsytelseService(
         val metadata = MetaInfo(correlationId = MDCUtil.callIdOrNew(), soknadDialogCommitSha = gitSha)
         val cacheKey = "${springTokenValidationContextHolder.personIdent()}_${rapportetInntekt.ytelse()}"
 
-        logger.info(formaterStatuslogging(rapportetInntekt.ytelse(), rapportetInntekt.søknadId(), "mottatt."))
+        logger.info(formaterStatuslogging(rapportetInntekt.ytelse(), rapportetInntekt.innsendingId(), "mottatt."))
         duplikatInnsendingSjekker.forsikreIkkeDuplikatInnsending(cacheKey)
         innsendingService.registrer(rapportetInntekt, metadata)
         metrikkService.registrerMottattInnsending(rapportetInntekt.ytelse())
@@ -69,7 +69,7 @@ class UngdomsytelseService(
         val metadata = MetaInfo(correlationId = MDCUtil.callIdOrNew(), soknadDialogCommitSha = gitSha)
         val cacheKey = "${springTokenValidationContextHolder.personIdent()}_${ungdomsytelseOppgavebekreftelseInnsending.ytelse()}"
 
-        logger.info(formaterStatuslogging(ungdomsytelseOppgavebekreftelseInnsending.ytelse(), ungdomsytelseOppgavebekreftelseInnsending.søknadId(), "mottatt."))
+        logger.info(formaterStatuslogging(ungdomsytelseOppgavebekreftelseInnsending.ytelse(), ungdomsytelseOppgavebekreftelseInnsending.innsendingId(), "mottatt."))
         duplikatInnsendingSjekker.forsikreIkkeDuplikatInnsending(cacheKey)
 
         innsendingService.registrer(ungdomsytelseOppgavebekreftelseInnsending, metadata)

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/OppgittInntekt.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/OppgittInntekt.kt
@@ -1,0 +1,13 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering
+
+import io.swagger.v3.oas.annotations.Hidden
+import jakarta.validation.constraints.AssertTrue
+
+data class OppgittInntekt(
+    val arbeidstakerOgFrilansInntekt: Int? = null,
+) {
+
+    @Hidden
+    @AssertTrue(message = "Må ha oppgitt inntekt fra arbeidstaker/frilans")
+    fun harOppgittInntekt(): Boolean = arbeidstakerOgFrilansInntekt != null
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseInntektsrapportering.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseInntektsrapportering.kt
@@ -3,11 +3,12 @@ package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
+import org.hibernate.validator.constraints.UUID
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 data class UngdomsytelseInntektsrapportering(
-    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    @field:UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
     val oppgaveReferanse: String,
 
     @Schema(hidden = true)

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseInntektsrapportering.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseInntektsrapportering.kt
@@ -20,12 +20,11 @@ import no.nav.k9.søknad.ytelse.ung.v1.UngdomsytelseSøknadValidator
 import java.net.URL
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.util.*
 import no.nav.k9.søknad.Søknad as UngSøknad
 
 data class UngdomsytelseInntektsrapportering(
-    @Schema(hidden = true)
-    val søknadId: String = UUID.randomUUID().toString(),
+    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    val oppgaveReferanse: String,
 
     @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
@@ -33,9 +32,9 @@ data class UngdomsytelseInntektsrapportering(
     @field:Valid val oppgittInntektForPeriode: OppgittInntektForPeriode,
 
     @field:AssertTrue(message = "Inntektsopplysningene må bekreftes for å kunne rapportere")
-    val harBekreftetInntekt: Boolean
+    val harBekreftetInntekt: Boolean,
 
-    ): Innsending {
+    ) : Innsending {
     companion object {
         private val K9_SØKNAD_VERSJON = Versjon.of("1.0.0")
     }
@@ -47,7 +46,7 @@ data class UngdomsytelseInntektsrapportering(
     ): UngdomsytelseKomplettInntektsrapportering {
         requireNotNull(k9Format)
         return UngdomsytelseKomplettInntektsrapportering(
-            søknadId = søknadId,
+            oppgaveReferanse = oppgaveReferanse,
             mottatt = mottatt,
             søker = søker,
             oppgittInntektForPeriode = oppgittInntektForPeriode,
@@ -67,7 +66,7 @@ data class UngdomsytelseInntektsrapportering(
             .medVersjon(K9_SØKNAD_VERSJON)
             .medMottattDato(mottatt)
             .medSpråk(Språk.NORSK_BOKMÅL)
-            .medSøknadId(SøknadId(søknadId))
+            .medSøknadId(SøknadId(oppgaveReferanse))
             .medSøker(søker.somK9Søker())
             .medYtelse(ytelse)
             .medKildesystem(Kildesystem.SØKNADSDIALOG)
@@ -75,7 +74,7 @@ data class UngdomsytelseInntektsrapportering(
 
     override fun søkerNorskIdent(): String? = null
     override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE_INNTEKTSRAPPORTERING
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = oppgaveReferanse
     override fun vedlegg(): List<URL> = mutableListOf()
     override fun søknadValidator(): SøknadValidator<Søknad> = UngdomsytelseSøknadValidator()
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseInntektsrapportering.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseInntektsrapportering.kt
@@ -3,24 +3,8 @@ package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
-import no.nav.brukerdialog.common.MetaInfo
-import no.nav.brukerdialog.domenetjenester.innsending.Innsending
-import no.nav.brukerdialog.oppslag.soker.Søker
-import no.nav.brukerdialog.ytelse.Ytelse
-import no.nav.k9.søknad.Søknad
-import no.nav.k9.søknad.SøknadValidator
-import no.nav.k9.søknad.felles.Kildesystem
-import no.nav.k9.søknad.felles.Versjon
-import no.nav.k9.søknad.felles.type.Språk
-import no.nav.k9.søknad.felles.type.SøknadId
-import no.nav.k9.søknad.ytelse.ung.v1.inntekt.OppgittInntekt
-import no.nav.k9.søknad.ytelse.ung.v1.UngSøknadstype
-import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
-import no.nav.k9.søknad.ytelse.ung.v1.UngdomsytelseSøknadValidator
-import java.net.URL
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import no.nav.k9.søknad.Søknad as UngSøknad
 
 data class UngdomsytelseInntektsrapportering(
     @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
@@ -29,52 +13,8 @@ data class UngdomsytelseInntektsrapportering(
     @Schema(hidden = true)
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
 
-    @field:Valid val oppgittInntektForPeriode: OppgittInntektForPeriode,
+    @field:Valid val oppgittInntekt: OppgittInntekt,
 
     @field:AssertTrue(message = "Inntektsopplysningene må bekreftes for å kunne rapportere")
-    val harBekreftetInntekt: Boolean,
-
-    ) : Innsending {
-    companion object {
-        private val K9_SØKNAD_VERSJON = Versjon.of("1.0.0")
-    }
-
-    override fun somKomplettSøknad(
-        søker: Søker,
-        k9Format: no.nav.k9.søknad.Innsending?,
-        titler: List<String>,
-    ): UngdomsytelseKomplettInntektsrapportering {
-        requireNotNull(k9Format)
-        return UngdomsytelseKomplettInntektsrapportering(
-            oppgaveReferanse = oppgaveReferanse,
-            mottatt = mottatt,
-            søker = søker,
-            oppgittInntektForPeriode = oppgittInntektForPeriode,
-            harBekreftetInntekt = harBekreftetInntekt,
-            k9Format = k9Format as UngSøknad
-        )
-    }
-
-    override fun valider() = mutableListOf<String>()
-
-    override fun somK9Format(søker: Søker, metadata: MetaInfo): UngSøknad {
-        val ytelse = Ungdomsytelse()
-            .medSøknadType(UngSøknadstype.RAPPORTERING_SØKNAD)
-            .medInntekter(OppgittInntekt(setOf(oppgittInntektForPeriode.somUngOppgittInntektForPeriode())))
-
-        return UngSøknad()
-            .medVersjon(K9_SØKNAD_VERSJON)
-            .medMottattDato(mottatt)
-            .medSpråk(Språk.NORSK_BOKMÅL)
-            .medSøknadId(SøknadId(oppgaveReferanse))
-            .medSøker(søker.somK9Søker())
-            .medYtelse(ytelse)
-            .medKildesystem(Kildesystem.SØKNADSDIALOG)
-    }
-
-    override fun søkerNorskIdent(): String? = null
-    override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE_INNTEKTSRAPPORTERING
-    override fun innsendingId(): String = oppgaveReferanse
-    override fun vedlegg(): List<URL> = mutableListOf()
-    override fun søknadValidator(): SøknadValidator<Søknad> = UngdomsytelseSøknadValidator()
-}
+    val harBekreftetInntekt: Boolean
+)

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseInntektsrapporteringInnsending.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseInntektsrapporteringInnsending.kt
@@ -1,0 +1,80 @@
+package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.AssertTrue
+import no.nav.brukerdialog.common.MetaInfo
+import no.nav.brukerdialog.domenetjenester.innsending.Innsending
+import no.nav.brukerdialog.oppslag.soker.Søker
+import no.nav.brukerdialog.ytelse.Ytelse
+import no.nav.k9.søknad.Søknad
+import no.nav.k9.søknad.SøknadValidator
+import no.nav.k9.søknad.felles.Kildesystem
+import no.nav.k9.søknad.felles.Versjon
+import no.nav.k9.søknad.felles.type.Språk
+import no.nav.k9.søknad.felles.type.SøknadId
+import no.nav.k9.søknad.ytelse.ung.v1.inntekt.OppgittInntekt
+import no.nav.k9.søknad.ytelse.ung.v1.UngSøknadstype
+import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
+import no.nav.k9.søknad.ytelse.ung.v1.UngdomsytelseSøknadValidator
+import java.net.URL
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import no.nav.k9.søknad.Søknad as UngSøknad
+
+data class UngdomsytelseInntektsrapporteringInnsending(
+    @field:org.hibernate.validator.constraints.UUID(message = "Forventet gyldig UUID, men var '\${validatedValue}'")
+    val oppgaveReferanse: String,
+
+    @Schema(hidden = true)
+    val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
+
+    @field:Valid val oppgittInntektForPeriode: OppgittInntektForPeriode,
+
+    @field:AssertTrue(message = "Inntektsopplysningene må bekreftes for å kunne rapportere")
+    val harBekreftetInntekt: Boolean,
+
+    ) : Innsending {
+    companion object {
+        private val K9_SØKNAD_VERSJON = Versjon.of("1.0.0")
+    }
+
+    override fun somKomplettSøknad(
+        søker: Søker,
+        k9Format: no.nav.k9.søknad.Innsending?,
+        titler: List<String>,
+    ): UngdomsytelseKomplettInntektsrapportering {
+        requireNotNull(k9Format)
+        return UngdomsytelseKomplettInntektsrapportering(
+            oppgaveReferanse = oppgaveReferanse,
+            mottatt = mottatt,
+            søker = søker,
+            oppgittInntektForPeriode = oppgittInntektForPeriode,
+            harBekreftetInntekt = harBekreftetInntekt,
+            k9Format = k9Format as UngSøknad
+        )
+    }
+
+    override fun valider() = mutableListOf<String>()
+
+    override fun somK9Format(søker: Søker, metadata: MetaInfo): UngSøknad {
+        val ytelse = Ungdomsytelse()
+            .medSøknadType(UngSøknadstype.RAPPORTERING_SØKNAD)
+            .medInntekter(OppgittInntekt(setOf(oppgittInntektForPeriode.somUngOppgittInntektForPeriode())))
+
+        return UngSøknad()
+            .medVersjon(K9_SØKNAD_VERSJON)
+            .medMottattDato(mottatt)
+            .medSpråk(Språk.NORSK_BOKMÅL)
+            .medSøknadId(SøknadId(oppgaveReferanse))
+            .medSøker(søker.somK9Søker())
+            .medYtelse(ytelse)
+            .medKildesystem(Kildesystem.SØKNADSDIALOG)
+    }
+
+    override fun søkerNorskIdent(): String? = null
+    override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE_INNTEKTSRAPPORTERING
+    override fun innsendingId(): String = oppgaveReferanse
+    override fun vedlegg(): List<URL> = mutableListOf()
+    override fun søknadValidator(): SøknadValidator<Søknad> = UngdomsytelseSøknadValidator()
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseKomplettInntektsrapportering.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/inntektsrapportering/UngdomsytelseKomplettInntektsrapportering.kt
@@ -6,10 +6,12 @@ import no.nav.k9.søknad.Søknad
 import java.time.ZonedDateTime
 
 data class UngdomsytelseKomplettInntektsrapportering(
-    private val søknadId: String,
-    private val søker: Søker,
-    private val oppgittInntektForPeriode: OppgittInntektForPeriode,
-    private val mottatt: ZonedDateTime,
-    private val harBekreftetInntekt: Boolean,
-    private val k9Format: Søknad,
-) : KomplettInnsending
+    val oppgaveReferanse: String,
+    val søker: Søker,
+    val oppgittInntektForPeriode: OppgittInntektForPeriode,
+    val mottatt: ZonedDateTime,
+    val harBekreftetInntekt: Boolean,
+    val k9Format: Søknad,
+) : KomplettInnsending {
+    override fun innsendingId(): String = oppgaveReferanse
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseKomplettOppgavebekreftelse.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseKomplettOppgavebekreftelse.kt
@@ -6,9 +6,11 @@ import no.nav.k9.oppgave.OppgaveBekreftelse
 import java.time.ZonedDateTime
 
 data class UngdomsytelseKomplettOppgavebekreftelse(
-    private val søknadId: String,
-    private val oppgave: KomplettUngdomsytelseOppgaveDTO,
-    private val søker: Søker,
-    private val mottatt: ZonedDateTime,
-    private val k9Format: OppgaveBekreftelse,
-) : KomplettInnsending
+    val søknadId: String,
+    val oppgave: KomplettUngdomsytelseOppgaveDTO,
+    val søker: Søker,
+    val mottatt: ZonedDateTime,
+    val k9Format: OppgaveBekreftelse,
+) : KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgavebekreftelseInnsending.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgavebekreftelseInnsending.kt
@@ -56,7 +56,7 @@ data class UngdomsytelseOppgavebekreftelseInnsending(
 
     override fun søkerNorskIdent(): String? = null
     override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE_OPPGAVEBEKREFTELSE
-    override fun søknadId(): String = komplettOppgavebekreftelse.oppgaveReferanse
+    override fun innsendingId(): String = komplettOppgavebekreftelse.oppgaveReferanse
     override fun vedlegg(): List<URL> = mutableListOf()
     override fun søknadValidator(): SøknadValidator<Søknad> = UngdomsytelseSøknadValidator()
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelseKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelseKomplettSøknad.kt
@@ -7,16 +7,18 @@ import java.time.LocalDate
 import java.time.ZonedDateTime
 
 data class UngdomsytelseKomplettSøknad(
-    private val søknadId: String,
-    private val søker: Søker,
-    private val språk: String,
-    private val startdato: LocalDate,
-    private val mottatt: ZonedDateTime,
-    private val barn: List<Barn>,
-    private val barnErRiktig: Boolean,
-    private val kontonummerFraRegister: String?,
-    private val kontonummerErRiktig: Boolean?,
-    private val harForståttRettigheterOgPlikter: Boolean,
-    private val harBekreftetOpplysninger: Boolean,
-    private val k9Format: Søknad,
-) : KomplettInnsending
+    val søknadId: String,
+    val søker: Søker,
+    val språk: String,
+    val startdato: LocalDate,
+    val mottatt: ZonedDateTime,
+    val barn: List<Barn>,
+    val barnErRiktig: Boolean,
+    val kontonummerFraRegister: String?,
+    val kontonummerErRiktig: Boolean?,
+    val harForståttRettigheterOgPlikter: Boolean,
+    val harBekreftetOpplysninger: Boolean,
+    val k9Format: Søknad,
+) : KomplettInnsending {
+    override fun innsendingId(): String = søknadId
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/Ungdomsytelsesøknad.kt
@@ -102,7 +102,7 @@ data class Ungdomsytelsesøknad(
 
     override fun søkerNorskIdent(): String? = søkerNorskIdent
     override fun ytelse(): Ytelse = Ytelse.UNGDOMSYTELSE
-    override fun søknadId(): String = søknadId
+    override fun innsendingId(): String = søknadId
     override fun vedlegg(): List<URL> = mutableListOf()
     override fun søknadValidator(): SøknadValidator<Søknad> = UngdomsytelseSøknadValidator()
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/inntektsrapportering/domene/UngdomsytelseInntektsrapporteringMottatt.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/inntektsrapportering/domene/UngdomsytelseInntektsrapporteringMottatt.kt
@@ -11,7 +11,7 @@ import no.nav.k9.søknad.Søknad
 import java.time.ZonedDateTime
 
 data class UngdomsytelseInntektsrapporteringMottatt(
-    val søknadId: String,
+    val oppgaveReferanse: String,
     val søker: Søker,
     val oppgittInntektForPeriode: OppgittInntektForPeriode,
     val mottatt: ZonedDateTime,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/inntektsrapportering/domene/UngdomsytelseInntektsrapporteringPreprosessert.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/inntektsrapportering/domene/UngdomsytelseInntektsrapporteringPreprosessert.kt
@@ -15,7 +15,7 @@ import java.util.*
 import no.nav.k9.søknad.Søknad as K9Søknad
 
 data class UngdomsytelseInntektsrapporteringPreprosessert(
-    val søknadId: String,
+    val oppgaveReferanse: String,
     val mottatt: ZonedDateTime,
     val søker: Søker,
     val oppgittInntektForPeriode: OppgittInntektForPeriode,
@@ -27,7 +27,7 @@ data class UngdomsytelseInntektsrapporteringPreprosessert(
         ungdomsytelseInntektsrapporteringMottatt: UngdomsytelseInntektsrapporteringMottatt,
         dokumentId: List<List<String>>,
     ) : this(
-        søknadId = ungdomsytelseInntektsrapporteringMottatt.søknadId,
+        oppgaveReferanse = ungdomsytelseInntektsrapporteringMottatt.oppgaveReferanse,
         mottatt = ungdomsytelseInntektsrapporteringMottatt.mottatt,
         søker = ungdomsytelseInntektsrapporteringMottatt.søker,
         oppgittInntektForPeriode = ungdomsytelseInntektsrapporteringMottatt.oppgittInntektForPeriode,
@@ -61,7 +61,7 @@ data class UngdomsytelseInntektsrapporteringPreprosessert(
 
     override fun tilK9DittnavVarsel(metadata: MetaInfo): K9Beskjed = K9Beskjed(
         metadata = metadata,
-        grupperingsId = søknadId,
+        grupperingsId = oppgaveReferanse,
         tekst = "Rapportert inntenkt for ungdomsytelsen er mottatt",
         link = null,
         dagerSynlig = 7,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseInntektsrapporteringPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseInntektsrapporteringPdfData.kt
@@ -24,7 +24,7 @@ class UngdomsytelseInntektsrapporteringPdfData(private val søknad: Ungdomsytels
         val k9Format = søknad.k9Format
         return mapOf(
             "tittel" to ytelse().utledTittel(språk()),
-            "søknadId" to søknad.søknadId,
+            "oppgaveReferanse" to søknad.oppgaveReferanse,
             "søknadMottattDag" to søknad.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
             "søknadMottatt" to DATE_TIME_FORMATTER.format(søknad.mottatt),
             "inntektForPeriode" to k9Format.getYtelse<Ungdomsytelse>().inntekter?.somMap(),

--- a/src/main/resources/handlebars/ungdomsytelse-rapportering-soknad.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-rapportering-soknad.hbs
@@ -43,7 +43,7 @@
 
 <!-- FOOTER -->
 <p id="footer">
-    <span class="soknadsid">{{ søknadId }}</span>
+    <span class="soknadsid">{{ oppgaveReferanse }}</span>
     <span class="soknadsid">{{ id }}</span>
     <span class="sidetall">side <span id="pagenumber"></span> av <span id="pagecount"></span></span>
 </p>

--- a/src/test/kotlin/no/nav/brukerdialog/AbstractIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/AbstractIntegrationTest.kt
@@ -7,23 +7,22 @@ import io.mockk.every
 import no.nav.brukerdialog.dittnavvarsel.DittnavVarselTopologyConfiguration.Companion.K9_DITTNAV_VARSEL_TOPIC
 import no.nav.brukerdialog.integrasjon.dokarkiv.DokarkivService
 import no.nav.brukerdialog.integrasjon.dokarkiv.dto.DokarkivJournalpostResponse
-import no.nav.brukerdialog.mellomlagring.dokument.Dokument
-import no.nav.brukerdialog.mellomlagring.dokument.DokumentEier
 import no.nav.brukerdialog.integrasjon.k9mellomlagring.K9DokumentMellomlagringService
-import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.integrasjon.k9selvbetjeningoppslag.BarnService
 import no.nav.brukerdialog.integrasjon.ungdeltakelseopplyser.UngDeltakelseOpplyserService
+import no.nav.brukerdialog.mellomlagring.dokument.Dokument
+import no.nav.brukerdialog.mellomlagring.dokument.DokumentEier
+import no.nav.brukerdialog.oppslag.barn.BarnOppslag
 import no.nav.brukerdialog.oppslag.soker.Søker
 import no.nav.brukerdialog.oppslag.soker.SøkerService
 import no.nav.brukerdialog.utils.KafkaIntegrationTest
 import no.nav.brukerdialog.utils.KafkaUtils.opprettKafkaConsumer
 import no.nav.brukerdialog.utils.KafkaUtils.opprettKafkaProducer
 import no.nav.security.mock.oauth2.MockOAuth2Server
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.ProgramperiodeDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgavetypeDataDTO
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.producer.Producer
 import org.junit.jupiter.api.AfterAll
@@ -149,17 +148,14 @@ abstract class AbstractIntegrationTest {
         return søker
     }
 
-    protected fun mockHentingAvOppgave() {
+    protected fun mockHentingAvOppgave(
+        oppgavetype: Oppgavetype,
+        oppgavetypeData: OppgavetypeDataDTO
+    ) {
         every { ungDeltakelseOpplyserService.hentOppgaveForDeltakelse(any()) } returns OppgaveDTO(
             oppgaveReferanse = UUID.randomUUID(),
-            oppgavetype = Oppgavetype.BEKREFT_ENDRET_PROGRAMPERIODE,
-            oppgavetypeData = EndretProgramperiodeDataDTO(
-                programperiode = ProgramperiodeDTO(
-                    fomDato = LocalDate.now(),
-                    tomDato = null
-                ),
-                forrigeProgramperiode = null
-            ),
+            oppgavetype = oppgavetype,
+            oppgavetypeData = oppgavetypeData,
             status = OppgaveStatus.ULØST,
             bekreftelse = null,
             opprettetDato = ZonedDateTime.now(),

--- a/src/test/kotlin/no/nav/brukerdialog/domenetjenester/innsending/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/domenetjenester/innsending/InnsendingServiceTest.kt
@@ -21,7 +21,6 @@ class InnsendingServiceTest {
         val innsendingService = InnsendingService(
             søkerService = mockk(),
             kafkaProdusent = mockk(),
-            objectMapper = mockk(),
             k9DokumentMellomlagringService = mockk(),
             springTokenValidationContextHolder = tokenValidationContextHolderMock,
         )

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseControllerTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseControllerTest.kt
@@ -21,6 +21,7 @@ import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.InntektrapporteringUtils
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.SøknadUtils
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
@@ -46,7 +47,8 @@ import java.util.*
     controllers = [UngdomsytelseController::class],
     properties = [
         "ENABLE_UNDOMSYTELSE=true",
-    ])
+    ]
+)
 @Import(
     JacksonConfiguration::class,
     CallIdGenerator::class,
@@ -112,6 +114,18 @@ class UngdomsytelseControllerTest {
         every { duplikatInnsendingSjekker.forsikreIkkeDuplikatInnsending(any()) } returns Unit
         coEvery { innsendingService.registrer(any(), any()) } returns Unit
         every { metrikkService.registrerMottattInnsending(any()) } returns Unit
+        every { ungDeltakelseOpplyserService.hentOppgaveForDeltakelse(any()) } returns OppgaveDTO(
+            oppgaveReferanse = UUID.randomUUID(),
+            oppgavetype = Oppgavetype.RAPPORTER_INNTEKT,
+            oppgavetypeData = InntektsrapporteringOppgavetypeDataDTO(
+                fraOgMed = LocalDate.now(),
+                tilOgMed = LocalDate.now()
+            ),
+            status = OppgaveStatus.ULØST,
+            bekreftelse = null,
+            opprettetDato = ZonedDateTime.now(),
+            løstDato = null
+        )
 
         val defaultInntektsrapportering = InntektrapporteringUtils.defaultInntektsrapportering
 

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseInntektRapporteringKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseInntektRapporteringKonsumentTest.kt
@@ -39,8 +39,8 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
         mockLagreDokument()
         mockJournalføring()
 
-        val søknadId = UUID.randomUUID().toString()
-        val inntektsrapportering = InntektrapporteringUtils.defaultInntektsrapportering.copy(søknadId = søknadId)
+        val oppgaveReferanse = UUID.randomUUID().toString()
+        val inntektsrapportering = InntektrapporteringUtils.defaultInntektsrapportering.copy(oppgaveReferanse = oppgaveReferanse)
 
         mockMvc.sendInnSøknad(inntektsrapportering, mockOAuth2Server.hentToken())
 
@@ -49,12 +49,12 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
         }
 
         k9DittnavVarselConsumer.lesMelding(
-            key = søknadId,
+            key = oppgaveReferanse,
             topic = DittnavVarselTopologyConfiguration.K9_DITTNAV_VARSEL_TOPIC
         ).value().assertDittnavVarsel(
             K9Beskjed(
                 metadata = no.nav.brukerdialog.utils.SøknadUtils.metadata,
-                grupperingsId = søknadId,
+                grupperingsId = oppgaveReferanse,
                 tekst = "Rapportert inntenkt for ungdomsytelsen er mottatt",
                 link = null,
                 dagerSynlig = 7,
@@ -103,7 +103,7 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
     @Language("JSON")
     private fun preprosessertSøknadSomJson(søknadId: String, mottatt: String) = """
         {
-          "søknadId": "$søknadId",
+          "oppgaveReferanse": "$søknadId",
           "mottatt": "$mottatt",
           "søker": {
             "etternavn": "Nordmann",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
@@ -18,6 +18,9 @@ import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.Un
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.oppgavebekreftelse.UngdomsytelseOppgavebekreftelseTopologyConfiguration
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.SøknadUtils
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelseOppgavebekreftelseUtils
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.ProgramperiodeDTO
 import org.intellij.lang.annotations.Language
 import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
@@ -26,6 +29,7 @@ import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.post
 import java.net.URI
+import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.*
 
@@ -45,7 +49,16 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
         mockBarn()
         mockLagreDokument()
         mockJournalføring()
-        mockHentingAvOppgave()
+        mockHentingAvOppgave(
+            oppgavetype = Oppgavetype.BEKREFT_ENDRET_PROGRAMPERIODE,
+            oppgavetypeData = EndretProgramperiodeDataDTO(
+                programperiode = ProgramperiodeDTO(
+                    fomDato = LocalDate.now(),
+                    tomDato = null
+                ),
+                forrigeProgramperiode = null
+            )
+        )
 
         val oppgaveReferanse = UUID.randomUUID()
         val oppgavebekreftelse = SøknadUtils.defaultOppgavebekreftelse.copy(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
@@ -2,6 +2,7 @@ package no.nav.brukerdialog.ytelse.ungdomsytelse.utils
 
 import no.nav.brukerdialog.config.JacksonConfiguration
 import no.nav.brukerdialog.ytelse.fellesdomene.Søker
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering.OppgittInntekt
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering.OppgittInntektForPeriode
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering.UngPeriode
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.inntektsrapportering.UngdomsytelseInntektsrapportering
@@ -10,7 +11,7 @@ import no.nav.k9.søknad.felles.Kildesystem
 import no.nav.k9.søknad.felles.Versjon
 import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer
 import no.nav.k9.søknad.felles.type.SøknadId
-import no.nav.k9.søknad.ytelse.ung.v1.inntekt.OppgittInntekt
+import no.nav.k9.søknad.ytelse.ung.v1.inntekt.OppgittInntekt as UngOppgittInntekt
 import no.nav.k9.søknad.ytelse.ung.v1.UngSøknadstype
 import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
 import java.time.LocalDate
@@ -24,13 +25,7 @@ object InntektrapporteringUtils {
     internal val defaultInntektsrapportering = UngdomsytelseInntektsrapportering(
         oppgaveReferanse = "4e62f8de-1ff6-40e9-bdcd-10485c789094",
         mottatt = ZonedDateTime.parse("2025-01-01T03:04:05Z", JacksonConfiguration.zonedDateTimeFormatter),
-        oppgittInntektForPeriode = OppgittInntektForPeriode(
-            arbeidstakerOgFrilansInntekt = 3000,
-            periodeForInntekt = UngPeriode(
-                fraOgMed = LocalDate.parse("2025-01-01"),
-                tilOgMed = LocalDate.parse("2025-01-31")
-            )
-        ),
+        oppgittInntekt = OppgittInntekt(arbeidstakerOgFrilansInntekt = 3000),
         harBekreftetInntekt = true,
     )
 
@@ -71,7 +66,7 @@ object InntektrapporteringUtils {
     ): k9FormatSøknad {
         val ytelse = Ungdomsytelse()
             .medSøknadType(UngSøknadstype.RAPPORTERING_SØKNAD)
-            .medInntekter(OppgittInntekt(setOf(oppgittInntektForPeriode.somUngOppgittInntektForPeriode())))
+            .medInntekter(UngOppgittInntekt(setOf(oppgittInntektForPeriode.somUngOppgittInntektForPeriode())))
 
         val søknad = k9FormatSøknad(
             SøknadId(søknadId),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
@@ -22,7 +22,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 
 object InntektrapporteringUtils {
     internal val defaultInntektsrapportering = UngdomsytelseInntektsrapportering(
-        søknadId = "4e62f8de-1ff6-40e9-bdcd-10485c789094",
+        oppgaveReferanse = "4e62f8de-1ff6-40e9-bdcd-10485c789094",
         mottatt = ZonedDateTime.parse("2025-01-01T03:04:05Z", JacksonConfiguration.zonedDateTimeFormatter),
         oppgittInntektForPeriode = OppgittInntektForPeriode(
             arbeidstakerOgFrilansInntekt = 3000,
@@ -48,7 +48,7 @@ object InntektrapporteringUtils {
     ): UngdomsytelseInntektsrapporteringMottatt {
 
         return UngdomsytelseInntektsrapporteringMottatt(
-            søknadId = søknadId,
+            oppgaveReferanse = søknadId,
             mottatt = mottatt,
             søker = Søker(
                 aktørId = "123456",


### PR DESCRIPTION
### **Behov / Bakgrunn**
Inntektsrapportering initieres som følge av en opprettet oppgave.

### **Løsning**
- Endrer fra `søknadId` til oppgaveReferanse på dto for innsending av rapportert inntekt.
- Henter og bruker oppgaven med periode ved innsending.
- Separer datastruktur for innsending og dto på endepunktet slik at frontend ikke trenger å sende inn data vi kan hente fra oppgaven.

### **Andre endringer**
- Renamer `søknadId` til `innsendingId` på `Innsending` interfacet.
- Legger til `innsendingId` på `KomplettInnsending` interfacet og fjerner `JSONObject` fra `InnsendingService`.
