### PR TITLE
PSB - Mapper opptjening i utlandet til k9-sak

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/OpptjeningIUtlandet.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/OpptjeningIUtlandet.kt
@@ -1,7 +1,10 @@
 package no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.api.domene
 
 import no.nav.brukerdialog.ytelse.fellesdomene.Land
+import no.nav.k9.søknad.felles.opptjening.UtenlandskArbeidsforhold
 import java.time.LocalDate
+
+import no.nav.k9.søknad.felles.type.Periode
 
 data class OpptjeningIUtlandet(
     val navn: String,
@@ -9,7 +12,12 @@ data class OpptjeningIUtlandet(
     val land: Land,
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate
-)
+) {
+    fun somUtenlandskArbeidsforhold() = UtenlandskArbeidsforhold()
+        .medLand(land.somK9Landkode())
+        .medArbeidsgiversnavn(navn)
+        .medAnsettelsePeriode(Periode(fraOgMed, tilOgMed))
+}
 
 enum class OpptjeningType {
     ARBEIDSTAKER,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/k9Format/K9OpptjeningAktivitet.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/k9Format/K9OpptjeningAktivitet.kt
@@ -19,6 +19,9 @@ internal fun PleiepengerSyktBarnSøknad.byggK9OpptjeningAktivitet(): OpptjeningA
     if (erFrilanserMedInntenkt) {
         opptjeningAktivitet.medFrilanser(frilans.tilK9Frilanser())
     }
+
+    opptjeningAktivitet.medUtenlandskeArbeidsforhold(opptjeningIUtlandet.map { it.somUtenlandskArbeidsforhold() })
+
     return opptjeningAktivitet
 }
 

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/k9Format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/k9Format/K9FormatTest.kt
@@ -126,7 +126,12 @@ class K9FormatTest {
                   "frilanser": {
                     "startdato": "2018-01-01",
                     "sluttdato": null
-                  }
+                  },
+                  "utenlandskeArbeidsforhold" : [{
+                  "ansettelsePeriode" : "2022-01-01/2022-01-10",
+                  "arbeidsgiversnavn" : "Kiwi AS",
+                  "land" : "BEL"
+                  }]
                 },
                 "dataBruktTilUtledning": null,
                 "infoFraPunsj": null,


### PR DESCRIPTION
### **Behov / Bakgrunn**
Får ikke reist riktig aksjonspunkt i k9-sak da det mangler opplysninger om opptjening i utlandet på søknaden.

### **Løsning**
- Mapper `OpptjeningIUtlandet` til UtenlandskArbeidsforhold på k9-format under opptjeningsaktivitet.