### PR TITLE
Slå på logging til både elastic og loki

### DIFF
--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -78,6 +78,10 @@ spec:
     enabled: true
     path: /metrics
   observability:
+    logging:
+      destinations:
+        - id: loki
+        - id: elastic
     autoInstrumentation:
       enabled: {{observabilityEnabled}}
       runtime: java


### PR DESCRIPTION
### **Behov / Bakgrunn**
Nav har bestemt seg for å fase ut Elastic som loggverktøy og gå over til å bruke Loki. Fra 1. juni blir ikke logger sendt til Elastic, med mindre man eksplisitt legger det til i naiserator filen. 

Logging til Elastic opphører ved slutten av 2025.

### **Løsning**
Sender logger både til Elastic og Loki