### PR TITLE
UNG - Splitter endret periode til to seperate oppgaver.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,8 +32,8 @@ repositories {
 
 val tokenSupportVersion = "5.0.25"
 val jsonassertVersion = "1.5.3"
-val k9FormatVersion = "12.2.0"
-val ungDeltakelseOpplyserVersjon = "1.14.0"
+val k9FormatVersion = "12.2.2"
+val ungDeltakelseOpplyserVersjon = "2.0.0"
 val springMockkVersion = "4.0.2"
 val logstashLogbackEncoderVersion = "8.1"
 val slf4jVersion = "2.0.17"

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgaveDTO.kt
@@ -3,7 +3,8 @@ package no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse
 import io.swagger.v3.oas.annotations.Hidden
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretSluttdatoDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretStartdatoDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
 import org.hibernate.validator.constraints.UUID
@@ -16,13 +17,19 @@ data class UngdomsytelseOppgaveDTO(
 ) {
 
     fun somKomplettOppgave(oppgaveDTO: OppgaveDTO): KomplettUngdomsytelseOppgaveDTO {
-        return when (oppgaveDTO.oppgavetypeData) {
-            is EndretProgramperiodeDataDTO -> {
-                val endretProgramperiodeDataDTO = oppgaveDTO.oppgavetypeData as EndretProgramperiodeDataDTO
-                return KomplettEndretPeriodeUngdomsytelseOppgaveDTO(
+        return when (val oppgavetypeData = oppgaveDTO.oppgavetypeData) {
+            is EndretStartdatoDataDTO -> {
+                return KomplettEndretStartdatoUngdomsytelseOppgaveDTO(
                     oppgaveReferanse = oppgaveReferanse,
-                    nyStartdato = endretProgramperiodeDataDTO.programperiode.fomDato,
-                    nySluttdato = endretProgramperiodeDataDTO.programperiode.fomDato,
+                    nyStartdato = oppgavetypeData.nyStartdato,
+                    uttalelse = uttalelse
+                )
+            }
+
+            is EndretSluttdatoDataDTO -> {
+                return KomplettEndretSluttdatoUngdomsytelseOppgaveDTO(
+                    oppgaveReferanse = oppgaveReferanse,
+                    nySluttdato = oppgavetypeData.nySluttdato,
                     uttalelse = uttalelse
                 )
             }
@@ -30,9 +37,9 @@ data class UngdomsytelseOppgaveDTO(
             is KontrollerRegisterinntektOppgavetypeDataDTO -> {
                 KomplettKontrollerRegisterInntektOppgaveTypeDataDTO(
                     oppgaveReferanse = oppgaveReferanse,
-                    fraOgMed = (oppgaveDTO.oppgavetypeData as KontrollerRegisterinntektOppgavetypeDataDTO).fraOgMed,
-                    tilOgMed = (oppgaveDTO.oppgavetypeData as KontrollerRegisterinntektOppgavetypeDataDTO).tilOgMed,
-                    registerinntekt = (oppgaveDTO.oppgavetypeData as KontrollerRegisterinntektOppgavetypeDataDTO).registerinntekt,
+                    fraOgMed = oppgavetypeData.fraOgMed,
+                    tilOgMed = oppgavetypeData.tilOgMed,
+                    registerinntekt = oppgavetypeData.registerinntekt,
                     uttalelse = uttalelse
                 )
             }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
@@ -9,7 +9,8 @@ import no.nav.brukerdialog.utils.DateUtils.somNorskDag
 import no.nav.brukerdialog.utils.NumberUtils.formaterSomValuta
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.BekreftelseSvar
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretPeriodeUngdomsytelseOppgaveDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretSluttdatoUngdomsytelseOppgaveDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretStartdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettKontrollerRegisterInntektOppgaveTypeDataDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveUttalelseDTO
@@ -42,12 +43,18 @@ class UngdomsytelseOppgavebekreftelsePdfData(private val oppgavebekreftelseMotta
     private fun KomplettUngdomsytelseOppgaveDTO.somMap() = mapOf(
         "oppgaveReferanse" to oppgaveReferanse,
         "uttalelse" to uttalelse.somMap(),
-        "endretPeriodeOppgave" to when (this) {
-            is KomplettEndretPeriodeUngdomsytelseOppgaveDTO -> mapOf(
-                "nyStartdato" to DATE_FORMATTER.format(nyStartdato),
-                "nySluttdato" to (nySluttdato?.let { DATE_FORMATTER.format(it) }),
-            )
 
+        "endretStartdatoOppgave" to when (this) {
+            is KomplettEndretStartdatoUngdomsytelseOppgaveDTO -> mapOf(
+                "nyStartdato" to DATE_FORMATTER.format(nyStartdato)
+            )
+            else -> null
+        },
+
+        "endretSluttdatoOppgave" to when (this) {
+            is KomplettEndretSluttdatoUngdomsytelseOppgaveDTO -> mapOf(
+                "nySluttdato" to DATE_FORMATTER.format(nySluttdato)
+            )
             else -> null
         },
 

--- a/src/main/resources/handlebars/ungdomsytelse-oppgave-bekreftelse.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-oppgave-bekreftelse.hbs
@@ -10,7 +10,7 @@
           content="{{tittel}} {{søknadMottattDag}} {{ søknadMottatt }}"/>
     <bookmarks>
         <bookmark name="Søker" href="#søker"/>
-        <bookmark name="Godkjenne endret periode" href="#endretPeriode"/>
+        <bookmark name="Godkjenne endret startdato" href="#endretStartdato"/>
         <bookmark name="Godkjenne endret sluttdato" href="#endretSluttdato"/>
         <bookmark name="Kontrollere inntekt fra register" href="#kontrollerRegisterInntektOppgave"/>
     </bookmarks>
@@ -27,25 +27,21 @@
 <div class="innholdscontainer">
     {{> partial/felles/personPartial id="søker" title="Søker" navn=søker.navn fødselsnummer=søker.fødselsnummer }}
 
-    {{#if oppgave.endretPeriodeOppgave}}
-        <section id="endretPeriode">
-            <h2>Godkjenn endret periode</h2>
+    {{#if oppgave.endretStartdatoOppgave}}
+        <section id="endretStartdato">
+            <h2>Godkjenn endret startdato</h2>
 
             <br/>
-            {{#if oppgave.endretPeriodeOppgave.nySluttdato}}
-                <p class="sporsmalstekst">Godkjenner du at perioden endres
-                    til {{oppgave.endretPeriodeOppgave.nyStartdato}} - {{oppgave.endretPeriodeOppgave.nySluttdato}}?</p>
-                <p>{{oppgave.uttalelse.bekreftelseSvar}}</p><br/>
-            {{else}}
-                <p class="sporsmalstekst">Godkjenner du at startdatoen endres
-                    til {{oppgave.endretPeriodeOppgave.nyStartdato}}?</p>
-                <p>{{oppgave.uttalelse.bekreftelseSvar}}</p><br/>
-            {{/if}}
+
+            <p class="sporsmalstekst">
+                Godkjenner du at startdatoen endres til {{oppgave.endretStartdatoOppgave.nyStartdato}}?
+            </p>
+            <p>{{oppgave.uttalelse.bekreftelseSvar}}</p><br/>
 
             {{> partial/ung/uttalelsePartial
                     uttalelse=oppgave.uttalelse
-                    spørsmålstekstBekreftelseSvar="Er perioden riktig?"
-                    spørsmålstekstBekreftelseSvarNei="Hvorfor stemmer ikke perioden?"
+                    spørsmålstekstBekreftelseSvar="Er startdatoen riktig?"
+                    spørsmålstekstBekreftelseSvarNei="Hvorfor stemmer ikke startdatoen?"
             }}
         </section>
     {{/if}}
@@ -55,8 +51,9 @@
             <h2>Godkjenn endret sluttdato</h2>
 
             <br/>
-            <p class="sporsmalstekst">Godkjenner du at sluttdato endres
-                til {{oppgave.endretSluttdatoOppgave.nySluttdato}}?</p>
+            <p class="sporsmalstekst">
+                Godkjenner du at sluttdato endres til {{oppgave.endretSluttdatoOppgave.nySluttdato}}?
+            </p>
             <p>{{oppgave.uttalelse.bekreftelseSvar}}</p><br/>
 
             {{> partial/ung/uttalelsePartial

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseControllerTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseControllerTest.kt
@@ -21,13 +21,12 @@ import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.InntektrapporteringUtils
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.SøknadUtils
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretStartdatoDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.SøkYtelseOppgavetypeDataDTO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.ProgramperiodeDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -235,13 +234,10 @@ class UngdomsytelseControllerTest {
         every { metrikkService.registrerMottattInnsending(any()) } returns Unit
         every { ungDeltakelseOpplyserService.hentOppgaveForDeltakelse(any()) } returns OppgaveDTO(
             oppgaveReferanse = UUID.randomUUID(),
-            oppgavetype = Oppgavetype.BEKREFT_ENDRET_PROGRAMPERIODE,
-            oppgavetypeData = EndretProgramperiodeDataDTO(
-                programperiode = ProgramperiodeDTO(
-                    fomDato = LocalDate.now(),
-                    tomDato = null
-                ),
-                forrigeProgramperiode = null
+            oppgavetype = Oppgavetype.BEKREFT_ENDRET_STARTDATO,
+            oppgavetypeData = EndretStartdatoDataDTO(
+                nyStartdato = LocalDate.now(),
+                forrigeStartdato = LocalDate.now().minusDays(30)
             ),
             status = OppgaveStatus.ULØST,
             bekreftelse = null,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
@@ -18,9 +18,8 @@ import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.Un
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.oppgavebekreftelse.UngdomsytelseOppgavebekreftelseTopologyConfiguration
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.SøknadUtils
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelseOppgavebekreftelseUtils
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretStartdatoDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.ProgramperiodeDTO
 import org.intellij.lang.annotations.Language
 import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
@@ -50,13 +49,10 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
         mockLagreDokument()
         mockJournalføring()
         mockHentingAvOppgave(
-            oppgavetype = Oppgavetype.BEKREFT_ENDRET_PROGRAMPERIODE,
-            oppgavetypeData = EndretProgramperiodeDataDTO(
-                programperiode = ProgramperiodeDTO(
-                    fomDato = LocalDate.now(),
-                    tomDato = null
-                ),
-                forrigeProgramperiode = null
+            oppgavetype = Oppgavetype.BEKREFT_ENDRET_STARTDATO,
+            oppgavetypeData = EndretStartdatoDataDTO(
+                nyStartdato = LocalDate.now(),
+                forrigeStartdato = LocalDate.now().minusMonths(1)
             )
         )
 
@@ -152,14 +148,13 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
     private fun preprosessertSøknadSomJson(oppgaveReferanse: String, mottatt: String) = """
         {
           "oppgave": {
-            "type": "BEKREFT_ENDRET_PROGRAMPERIODE",
+            "type": "UNG_ENDRET_STARTDATO",
             "oppgaveReferanse": "$oppgaveReferanse",
             "uttalelse": {
                 "bekreftelseSvar": "GODTAR",
                 "meldingFraDeltaker": null
             },
-            "nyStartdato": "2025-01-01",
-            "nySluttdato": "2025-12-01"
+            "nyStartdato": "2025-12-01"
           },
           "mottatt": "$mottatt",
           "søker": {
@@ -186,8 +181,8 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
               "norskIdentitetsnummer": "02119970078"
             },
             "bekreftelse": {
-              "type": "UNG_ENDRET_PROGRAMPERIODE",
-              "nyPeriode": "2025-01-01/2025-12-01",
+              "type": "UNG_ENDRET_STARTDATO",
+              "nyStartdato": "2025-12-01",
               "oppgaveReferanse": "$oppgaveReferanse",
               "uttalelseFraBruker": null,
               "harBrukerGodtattEndringen": true,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsyteleOppgavebekreftelsePdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsyteleOppgavebekreftelsePdfGeneratorTest.kt
@@ -3,7 +3,8 @@ package no.nav.brukerdialog.ytelse.ungdomsytelse.pdf
 import no.nav.brukerdialog.pdf.PDFGenerator
 import no.nav.brukerdialog.utils.PathUtils.pdfPath
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.BekreftelseSvar
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretPeriodeUngdomsytelseOppgaveDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretSluttdatoUngdomsytelseOppgaveDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretStartdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettKontrollerRegisterInntektOppgaveTypeDataDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveUttalelseDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelseOppgavebekreftelseUtils
@@ -33,30 +34,60 @@ class UngdomsyteleOppgavebekreftelsePdfGeneratorTest {
         val generator = PDFGenerator()
 
         fun genererOppsummeringsPdfer(writeBytes: Boolean) {
-            var id = "1-godtar-endret-periode"
+            var id = "1-godtar-endret-startdato"
             var pdf = generator.genererPDF(
                 UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt().pdfData()
             )
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
 
-            id = "2-avslår-endret-periode"
+            id = "2-avslår-endret-startdato"
             pdf = generator.genererPDF(
                 UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt()
                     .copy(
-                        oppgave = KomplettEndretPeriodeUngdomsytelseOppgaveDTO(
+                        oppgave = KomplettEndretStartdatoUngdomsytelseOppgaveDTO(
                             oppgaveReferanse = UUID.randomUUID().toString(),
                             uttalelse = UngdomsytelseOppgaveUttalelseDTO(
                                 bekreftelseSvar = BekreftelseSvar.AVSLÅR,
                                 meldingFraDeltaker = "Jeg ønsker en senere startdato"
                             ),
                             nyStartdato = LocalDate.parse("2025-01-01"),
-                            //nySluttdato = LocalDate.parse("2025-12-01"),
                         )
                     ).pdfData()
             )
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
 
-            id = "3-godtar-kontrollert-registerinntekt"
+            id = "3-godtar-endret-sluttdato"
+            pdf = generator.genererPDF(
+                UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt()
+                    .copy(
+                        oppgave = KomplettEndretSluttdatoUngdomsytelseOppgaveDTO(
+                            oppgaveReferanse = UUID.randomUUID().toString(),
+                            uttalelse = UngdomsytelseOppgaveUttalelseDTO(
+                                bekreftelseSvar = BekreftelseSvar.GODTAR,
+                            ),
+                            nySluttdato = LocalDate.parse("2025-01-01"),
+                        )
+                    ).pdfData()
+            )
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+            id = "4-avslår-endret-sluttdato"
+            pdf = generator.genererPDF(
+                UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt()
+                    .copy(
+                        oppgave = KomplettEndretSluttdatoUngdomsytelseOppgaveDTO(
+                            oppgaveReferanse = UUID.randomUUID().toString(),
+                            uttalelse = UngdomsytelseOppgaveUttalelseDTO(
+                                bekreftelseSvar = BekreftelseSvar.AVSLÅR,
+                                meldingFraDeltaker = "Jeg ønsker en senere sluttdato"
+                            ),
+                            nySluttdato = LocalDate.parse("2025-01-01"),
+                        )
+                    ).pdfData()
+            )
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+            id = "5-godtar-kontrollert-registerinntekt"
             pdf = generator.genererPDF(
                 UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt()
                     .copy(
@@ -94,7 +125,7 @@ class UngdomsyteleOppgavebekreftelsePdfGeneratorTest {
             )
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
 
-            id = "4-avslår-kontrollert-registerinntekt"
+            id = "6-avslår-kontrollert-registerinntekt"
             pdf = generator.genererPDF(
                 UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt()
                     .copy(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelseOppgavebekreftelseUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelseOppgavebekreftelseUtils.kt
@@ -2,7 +2,7 @@ package no.nav.brukerdialog.ytelse.ungdomsytelse.utils
 
 import no.nav.brukerdialog.ytelse.fellesdomene.Søker
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.BekreftelseSvar
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretPeriodeUngdomsytelseOppgaveDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretStartdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveUttalelseDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.oppgavebekreftelse.domene.UngdomsytelseOppgavebekreftelseMottatt
@@ -21,13 +21,12 @@ object UngdomsytelseOppgavebekreftelseUtils {
     fun oppgavebekreftelseMottatt(
         søkerFødselsnummer: String = "02119970078",
         oppgaveReferanse: String = UUID.randomUUID().toString(),
-        oppgave: KomplettUngdomsytelseOppgaveDTO = KomplettEndretPeriodeUngdomsytelseOppgaveDTO(
+        oppgave: KomplettUngdomsytelseOppgaveDTO = KomplettEndretStartdatoUngdomsytelseOppgaveDTO(
             oppgaveReferanse = oppgaveReferanse,
             uttalelse = UngdomsytelseOppgaveUttalelseDTO(
                 bekreftelseSvar = BekreftelseSvar.GODTAR
             ),
-            nyStartdato = LocalDate.parse("2025-01-01"),
-            nySluttdato = LocalDate.parse("2025-12-01"),
+            nyStartdato = LocalDate.parse("2025-12-01"),
         ),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
     ): UngdomsytelseOppgavebekreftelseMottatt {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Endringene splittes i to separate oppgavetyper som deltaker får mulighet til å vurdere separat. Dette gjøres for å gjøre det enklere for deltaker å vite hva som skal vurderes i hver oppgave.

### **Løsning**
- Utvider oppgavebekreftelse med støtte for endret startdato/sluttdato oppgaver.
- Mapper til korrekt k9 oppgave bekreftelse.
- Tilpasser PDF for disse to oppgavene.
