### PR TITLE
UNG - Mapper deltakelseId til k9Format.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ repositories {
 
 val tokenSupportVersion = "5.0.25"
 val jsonassertVersion = "1.5.3"
-val k9FormatVersion = "12.2.2"
+val k9FormatVersion = "12.3.0"
 val ungDeltakelseOpplyserVersjon = "2.0.1"
 val springMockkVersion = "4.0.2"
 val logstashLogbackEncoderVersion = "8.1"

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseService.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseService.kt
@@ -53,6 +53,7 @@ class UngdomsytelseService(
 
         val ungdomsytelsesøknadInnsending = UngdomsytelsesøknadInnsending(
             oppgaveReferanse = søknad.oppgaveReferanse,
+            deltakelseId = søknad.deltakelseId,
             språk = søknad.språk,
             mottatt = søknad.mottatt,
             startdato = søkYtelseOppgavetypeDataDTO.fomDato,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelsesøknadInnsending.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/soknad/UngdomsytelsesøknadInnsending.kt
@@ -22,6 +22,8 @@ import no.nav.k9.søknad.Søknad as UngSøknad
 
 data class UngdomsytelsesøknadInnsending(
     val oppgaveReferanse: String = UUID.randomUUID().toString(),
+    val deltakelseId: String,
+
     val språk: String,
 
     val mottatt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
@@ -72,6 +74,7 @@ data class UngdomsytelsesøknadInnsending(
         val ytelse = Ungdomsytelse()
             .medStartdato(startdato)
             .medSøknadType(SØKNAD_TYPE)
+            .medDeltakelseId(UUID.fromString(deltakelseId))
 
         return UngSøknad()
             .medVersjon(K9_SØKNAD_VERSJON)

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseInntektRapporteringKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseInntektRapporteringKonsumentTest.kt
@@ -96,10 +96,11 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
     @Test
     fun `Forvent at melding bli prosessert på 5 forsøk etter 4 feil`() {
         val søknadId = UUID.randomUUID().toString()
+        val deltakelseId = UUID.randomUUID()
         val mottattString = "2020-01-01T10:30:15Z"
         val mottatt = ZonedDateTime.parse(mottattString, JacksonConfiguration.zonedDateTimeFormatter)
         val inntektsrapportering =
-            InntektrapporteringUtils.gyldigInntektsrapportering(søknadId = søknadId, mottatt = mottatt)
+            InntektrapporteringUtils.gyldigInntektsrapportering(søknadId = søknadId, deltakelseId = deltakelseId, mottatt = mottatt)
         val correlationId = UUID.randomUUID().toString()
         val metadata = MetaInfo(version = 1, correlationId = correlationId)
         val topicEntry = TopicEntry(metadata, inntektsrapportering)
@@ -125,11 +126,11 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
             ).value()
 
         val preprosessertSøknadJson = JSONObject(lesMelding).getJSONObject("data").toString()
-        JSONAssert.assertEquals(preprosessertSøknadSomJson(søknadId, mottattString), preprosessertSøknadJson, true)
+        JSONAssert.assertEquals(preprosessertSøknadSomJson(søknadId, deltakelseId.toString(), mottattString), preprosessertSøknadJson, true)
     }
 
     @Language("JSON")
-    private fun preprosessertSøknadSomJson(søknadId: String, mottatt: String) = """
+    private fun preprosessertSøknadSomJson(søknadId: String, deltakelseId: String, mottatt: String) = """
         {
           "oppgaveReferanse": "$søknadId",
           "mottatt": "$mottatt",
@@ -166,6 +167,7 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
             "ytelse": {
               "type": "UNGDOMSYTELSE",
               "søknadType": "RAPPORTERING_SØKNAD",
+              "deltakelseId": "$deltakelseId",
               "søktFraDatoer": [],
               "inntekter": {
                 "oppgittePeriodeinntekter": [

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
@@ -32,6 +32,7 @@ object InntektrapporteringUtils {
     fun gyldigInntektsrapportering(
         søkerFødselsnummer: String = "02119970078",
         søknadId: String = UUID.randomUUID().toString(),
+        deltakelseId: UUID = UUID.randomUUID(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
         oppgittInntektForPeriode: OppgittInntektForPeriode = OppgittInntektForPeriode(
             arbeidstakerOgFrilansInntekt = 6000,
@@ -55,17 +56,19 @@ object InntektrapporteringUtils {
             ),
             oppgittInntektForPeriode = oppgittInntektForPeriode,
             harBekreftetInntekt = true,
-            k9Format = gyldigK9Format(søknadId, mottatt, oppgittInntektForPeriode)
+            k9Format = gyldigK9Format(søknadId, deltakelseId, mottatt, oppgittInntektForPeriode)
         )
     }
 
     fun gyldigK9Format(
         søknadId: String = UUID.randomUUID().toString(),
+        deltakelseId: UUID = UUID.randomUUID(),
         mottatt: ZonedDateTime,
         oppgittInntektForPeriode: OppgittInntektForPeriode,
     ): k9FormatSøknad {
         val ytelse = Ungdomsytelse()
             .medSøknadType(UngSøknadstype.RAPPORTERING_SØKNAD)
+            .medDeltakelseId(deltakelseId)
             .medInntekter(UngOppgittInntekt(setOf(oppgittInntektForPeriode.somUngOppgittInntektForPeriode())))
 
         val søknad = k9FormatSøknad(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
@@ -22,6 +22,7 @@ object UngdomsytelsesøknadUtils {
         søkerFødselsnummer: String = "02119970078",
         søknadId: String = UUID.randomUUID().toString(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
+        deltakelseId: UUID = UUID.randomUUID(),
     ): UngdomsytelsesøknadMottatt {
         val startdato = LocalDate.parse("2022-01-01")
 
@@ -46,7 +47,7 @@ object UngdomsytelsesøknadUtils {
             barnErRiktig = true,
             kontonummerFraRegister = "12345678901",
             kontonummerErRiktig = true,
-            k9Format = gyldigK9Format(søknadId, mottatt, startdato),
+            k9Format = gyldigK9Format(søknadId, deltakelseId, mottatt, startdato),
             harBekreftetOpplysninger = true,
             harForståttRettigheterOgPlikter = true
         )
@@ -54,12 +55,14 @@ object UngdomsytelsesøknadUtils {
 
     fun gyldigK9Format(
         søknadId: String = UUID.randomUUID().toString(),
+        deltakelseId: UUID = UUID.randomUUID(),
         mottatt: ZonedDateTime,
         fraOgMed: LocalDate,
     ): k9FormatSøknad {
         val ytelse = Ungdomsytelse()
             .medSøknadType(UngSøknadstype.DELTAKELSE_SØKNAD)
             .medStartdato(fraOgMed)
+            .medDeltakelseId(deltakelseId)
 
         val søknad = k9FormatSøknad(
             SøknadId(søknadId),


### PR DESCRIPTION
### **Behov / Bakgrunn**
I registerappen utleder man deltakelse utifra startdato oppgitt i søknaden som samsvarer med startdato i deltakelsen.
Men hvis søknad på kø skulle feile, e.g. pga. feilende journalføring, og veileder endrer startdato, vil man ikke kunne utlede deltakelsen.

### **Løsning**
Legger til deltakelseId på søknaden slik at vi kan finne fram til riktig deltakelse i ung-deltakelse-opplyser.

Relevant PR: https://github.com/navikt/ung-deltakelse-opplyser/pull/124
