### PR TITLE
UNG - Endrer brevkoder i tråd med navnstandard til felleskodeverk.

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/dto/YtelseType.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/dto/YtelseType.kt
@@ -162,24 +162,24 @@ enum class YtelseType(
     ),
 
     UNGDOMSYTELSE_SØKNAD(
-        brevkode = BrevKode(brevKode = "UNG Søknad", dokumentKategori = "SOK"),
-        tittel = "Søknad om ungdomsytelse - UNG Søknad",
+        brevkode = BrevKode(brevKode = "NAV 76-13.92", dokumentKategori = "SOK"),
+        tittel = "Søknad om ungdomsprogramytelsen - NAV 76-13.92",
         tema = Tema.UNGDOMSYTELSE,
         innsendingstype = Innsendingstype.SØKNAD
-    ),
-
-    UNGDOMSYTELSE_OPPGAVEBEKREFTELSE(
-        brevkode = BrevKode(brevKode = "UNG Oppgavebekreftelse", dokumentKategori = "SOK"),
-        tittel = "Bekreftelse for endring av ungdomsytelse - UNG Oppgavebekreftelse",
-        tema = Tema.UNGDOMSYTELSE,
-        innsendingstype = Innsendingstype.ENDRING
     ),
 
     UNGDOMSYTELSE_INNTEKTRAPPORTERING(
-        brevkode = BrevKode(brevKode = "UNG Inntektrapportering", dokumentKategori = "SOK"),
-        tittel = "Rapporteringsmelding for ungdomsprogramytelsen - UNG Inntektrapportering",
+        brevkode = BrevKode(brevKode = "NAV 76-13.93", dokumentKategori = "SOK"),
+        tittel = "Rapporteringsmelding for ungdomsprogramytelsen - NAV 76-13.93",
         tema = Tema.UNGDOMSYTELSE,
         innsendingstype = Innsendingstype.SØKNAD
+    ),
+
+    UNGDOMSYTELSE_UTTALELSE_PÅ_FORHÅNDSVARSEL(
+        brevkode = BrevKode(brevKode = "NAV 76-13.94", dokumentKategori = "SOK"),
+        tittel = "Uttalelse på forhåndsvarsel for ungdomsprogramytelsen - NAV 76-13.94",
+        tema = Tema.UNGDOMSYTELSE,
+        innsendingstype = Innsendingstype.ENDRING
     )
     ;
 

--- a/src/main/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/dto/YtelseType.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/dto/YtelseType.kt
@@ -163,21 +163,21 @@ enum class YtelseType(
 
     UNGDOMSYTELSE_SØKNAD(
         brevkode = BrevKode(brevKode = "NAV 76-13.92", dokumentKategori = "SOK"),
-        tittel = "Søknad om ungdomsprogramytelsen - NAV 76-13.92",
+        tittel = "Søknad om ungdomsprogramytelse - NAV 76-13.92",
         tema = Tema.UNGDOMSYTELSE,
         innsendingstype = Innsendingstype.SØKNAD
     ),
 
     UNGDOMSYTELSE_INNTEKTRAPPORTERING(
         brevkode = BrevKode(brevKode = "NAV 76-13.93", dokumentKategori = "SOK"),
-        tittel = "Rapporteringsmelding for ungdomsprogramytelsen - NAV 76-13.93",
+        tittel = "Rapporteringsmelding for ungdomsprogramytelse - NAV 76-13.93",
         tema = Tema.UNGDOMSYTELSE,
         innsendingstype = Innsendingstype.SØKNAD
     ),
 
-    UNGDOMSYTELSE_UTTALELSE_PÅ_FORHÅNDSVARSEL(
+    UNGDOMSYTELSE_VARSEL_UTTALELSE(
         brevkode = BrevKode(brevKode = "NAV 76-13.94", dokumentKategori = "SOK"),
-        tittel = "Uttalelse på forhåndsvarsel for ungdomsprogramytelsen - NAV 76-13.94",
+        tittel = "Uttalelse på forhåndsvarsel for ungdomsprogramytelse - NAV 76-13.94",
         tema = Tema.UNGDOMSYTELSE,
         innsendingstype = Innsendingstype.ENDRING
     )

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/oppgavebekreftelse/domene/UngdomsytelseOppgavebekreftelsePreprosessert.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/oppgavebekreftelse/domene/UngdomsytelseOppgavebekreftelsePreprosessert.kt
@@ -48,7 +48,7 @@ data class UngdomsytelseOppgavebekreftelsePreprosessert(
     override fun tilJournaførigsRequest(): JournalføringsService.JournalføringsRequest {
 
         return JournalføringsService.JournalføringsRequest(
-            ytelseType = YtelseType.UNGDOMSYTELSE_UTTALELSE_PÅ_FORHÅNDSVARSEL,
+            ytelseType = YtelseType.UNGDOMSYTELSE_VARSEL_UTTALELSE,
             norskIdent = søkerFødselsnummer(),
             sokerNavn = søkerNavn(),
             mottatt = mottatt,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/oppgavebekreftelse/domene/UngdomsytelseOppgavebekreftelsePreprosessert.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/oppgavebekreftelse/domene/UngdomsytelseOppgavebekreftelsePreprosessert.kt
@@ -48,7 +48,7 @@ data class UngdomsytelseOppgavebekreftelsePreprosessert(
     override fun tilJournaførigsRequest(): JournalføringsService.JournalføringsRequest {
 
         return JournalføringsService.JournalføringsRequest(
-            ytelseType = YtelseType.UNGDOMSYTELSE_OPPGAVEBEKREFTELSE,
+            ytelseType = YtelseType.UNGDOMSYTELSE_UTTALELSE_PÅ_FORHÅNDSVARSEL,
             norskIdent = søkerFødselsnummer(),
             sokerNavn = søkerNavn(),
             mottatt = mottatt,

--- a/src/test/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/DokarkivResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/DokarkivResponseTransformer.kt
@@ -31,10 +31,10 @@ internal class DokarkivResponseTransformer : ResponseTransformer() {
             YtelseType.PLEIEPENGESØKNAD_LIVETS_SLUTTFASE to "16",
             YtelseType.PLEIEPENGESØKNAD_LIVETS_SLUTTFASE_ETTERSENDING to "17",
             YtelseType.OMSORGSDAGER_ALENEOMSORG_ETTERSENDING to "18",
-            YtelseType.UNGDOMSYTELSE_SØKNAD to "19", // TODO Bruk Tema.UNGDOMSYTELSE før lansering
-            YtelseType.UNGDOMSYTELSE_INNTEKTRAPPORTERING to "20", // TODO Bruk Tema.UNGDOMSYTELSE før lansering
+            YtelseType.UNGDOMSYTELSE_SØKNAD to "19",
+            YtelseType.UNGDOMSYTELSE_INNTEKTRAPPORTERING to "20",
             YtelseType.OPPLÆRINGSPENGERSØKNAD_ETTERSENDING to "21",
-            YtelseType.UNGDOMSYTELSE_OPPGAVEBEKREFTELSE to "22", // TODO Bruk Tema.UNGDOMSYTELSE før lansering
+            YtelseType.UNGDOMSYTELSE_UTTALELSE_PÅ_FORHÅNDSVARSEL to "22",
         )
     }
 

--- a/src/test/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/DokarkivResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/integrasjon/dokarkiv/DokarkivResponseTransformer.kt
@@ -34,7 +34,7 @@ internal class DokarkivResponseTransformer : ResponseTransformer() {
             YtelseType.UNGDOMSYTELSE_SØKNAD to "19",
             YtelseType.UNGDOMSYTELSE_INNTEKTRAPPORTERING to "20",
             YtelseType.OPPLÆRINGSPENGERSØKNAD_ETTERSENDING to "21",
-            YtelseType.UNGDOMSYTELSE_UTTALELSE_PÅ_FORHÅNDSVARSEL to "22",
+            YtelseType.UNGDOMSYTELSE_VARSEL_UTTALELSE to "22",
         )
     }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Brevkodene må følge format for andre brevkoder i NAV.

### **Løsning**
Endrer brevkoder i tråd med navnstandard til felles kodeverk for Nav skjemaer:

- `UNG Søknad --> NAV 76-13.92`
- `UNG Inntektrapportering --> NAV 76-13.93`
- `UNG Oppgavebekreftelse --> NAV 76-13.94`

Denne må merges inn ca. samtidig som https://github.com/navikt/ung-sak/pull/526.

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
