### PR TITLE
TSFF-1765: Legg til spørsmål om ettersendelse i søknad for opplæringspenger

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/EttersendingAvVedlegg.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/EttersendingAvVedlegg.kt
@@ -1,0 +1,25 @@
+package no.nav.brukerdialog.ytelse.opplæringspenger.api.domene
+
+import jakarta.validation.constraints.AssertTrue
+import org.jetbrains.annotations.NotNull
+
+data class EttersendingAvVedlegg(
+    @field:NotNull val skalEttersendeVedlegg: Boolean,
+    val vedleggSomSkalEttersendes: List<VedleggType>?
+) {
+
+    @AssertTrue(message = "Vedlegg som skal ettersendes kan ikke være tomt når skalEttersendeVedlegg er true.")
+    fun isValid(): Boolean {
+        if (skalEttersendeVedlegg) {
+            return !vedleggSomSkalEttersendes.isNullOrEmpty()
+        }
+        return true
+    }
+
+}
+
+ enum class VedleggType(val beskrivelse: String) {
+     LEGEERKLÆRING("Signert legeerklæring"),
+     KURSINFORMASJON("Informasjon om kurs"),
+     ANNET("Annet"),
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/KomplettOpplæringspengerSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/KomplettOpplæringspengerSøknad.kt
@@ -32,6 +32,7 @@ data class KomplettOpplæringspengerSøknad(
     val stønadGodtgjørelse: StønadGodtgjørelse? = null,
     val selvstendigNæringsdrivende: SelvstendigNæringsdrivendeOLP? = null,
     val harVærtEllerErVernepliktig: Boolean? = null,
+    val ettersendingAvVedlegg: EttersendingAvVedlegg? = null, // TODO: fjern nullable når vi har lansert ettersendingAvVedlegg og mellomlagring inneholder dette feltet.
     val kurs: Kurs,
     val k9FormatSøknad: Søknad? = null,
 ) : KomplettInnsending {

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/OpplæringspengerSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/OpplæringspengerSøknad.kt
@@ -96,6 +96,9 @@ data class OpplæringspengerSøknad(
     val dataBruktTilUtledningAnnetData: String? = null,
 
     @field:Valid
+    val ettersendingAvVedlegg: EttersendingAvVedlegg? = null, // TODO: fjern nullable når vi har lansert ettersendingAvVedlegg og mellomlagring inneholder dette feltet.
+
+    @field:Valid
     val kurs: Kurs
 ) : Innsending {
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/OLPMottattSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/OLPMottattSøknad.kt
@@ -33,6 +33,7 @@ data class OLPMottattSøknad(
     val selvstendigNæringsdrivende: SelvstendigNæringsdrivende? = null,
     val arbeidsgivere: List<Arbeidsgiver>,
     val harVærtEllerErVernepliktig: Boolean? = null,
+    val ettersendingAvVedlegg: EttersendingAvVedlegg? = null, // TODO: fjern nullable når vi har lansert ettersendingAvVedlegg og mellomlagring inneholder dette feltet.
     val kurs: Kurs,
     val k9FormatSøknad: Søknad
 ): MottattMelding {

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/OLPPreprosessertSøknad.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/OLPPreprosessertSøknad.kt
@@ -36,6 +36,7 @@ data class OLPPreprosessertSøknad(
     val harForstattRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean,
     val harVærtEllerErVernepliktig: Boolean? = null,
+    val ettersendingAvVedlegg: EttersendingAvVedlegg? = null, // TODO: fjern nullable når vi har lansert ettersendingAvVedlegg og mellomlagring inneholder dette feltet.
     val k9FormatSøknad: Søknad,
 ) : Preprosessert {
     constructor(
@@ -62,6 +63,7 @@ data class OLPPreprosessertSøknad(
         harBekreftetOpplysninger = melding.harBekreftetOpplysninger,
         ferieuttakIPerioden = melding.ferieuttakIPerioden,
         harVærtEllerErVernepliktig = melding.harVærtEllerErVernepliktig,
+        ettersendingAvVedlegg = melding.ettersendingAvVedlegg,
         k9FormatSøknad = melding.k9FormatSøknad
     )
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/EttersendingAvVedlegg.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/EttersendingAvVedlegg.kt
@@ -1,0 +1,12 @@
+package no.nav.brukerdialog.ytelse.opplæringspenger.kafka.domene.felles
+
+data class EttersendingAvVedlegg(
+    val skalEttersendeVedlegg: Boolean,
+    val vedleggSomSkalEttersendes: List<VedleggType>?
+)
+
+ enum class VedleggType(val beskrivelse: String) {
+     LEGEERKLÆRING("Signert legeerklæring"),
+     KURSINFORMASJON("Informasjon om kurs"),
+     ANNET("Annet"),
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
@@ -69,6 +69,11 @@ class OLPSøknadPdfData(private val søknad: OLPMottattSøknad) : PdfData() {
             "frilans" to søknad.frilans?.somMap(),
             "selvstendigNæringsdrivende" to søknad.selvstendigNæringsdrivende?.somMap(),
             "arbeidsgivere" to søknad.arbeidsgivere.somMapAnsatt(),
+            "ettersendingAvVedlegg" to søknad.ettersendingAvVedlegg?.let { mapOf(
+                "skalEttersendeVedlegg" to it.skalEttersendeVedlegg,
+                "vedleggSomSkalEttersendes" to it.vedleggSomSkalEttersendes?.map { it.beskrivelse }
+            )
+            },
             "hjelper" to mapOf(
                 "harFlereAktiveVirksomheterErSatt" to søknad.harFlereAktiveVirksomehterSatt(),
                 "harVærtEllerErVernepliktigErSatt" to erBooleanSatt(søknad.harVærtEllerErVernepliktig),

--- a/src/main/resources/handlebars/opplaeringspenger-soknad.hbs
+++ b/src/main/resources/handlebars/opplaeringspenger-soknad.hbs
@@ -408,6 +408,23 @@
             <p>Har lastet opp dokumentasjon.</p>
         {{/if}}
 
+        {{#if ettersendingAvVedlegg}}
+            <hr/>
+            <p class="sporsmalstekst">Skal du ettersende vedlegg?</p>
+            <p>{{ jaNeiSvar ettersendingAvVedlegg.skalEttersendeVedlegg }}</p>
+            {{#if ettersendingAvVedlegg.skalEttersendeVedlegg }}
+                <hr/>
+                <p class="sporsmalstekst">Vedlegg som skal ettersendes:</p>
+                <ul>
+                    {{#each ettersendingAvVedlegg.vedleggSomSkalEttersendes as |vedlegg|~}}
+                        <li>
+                            <p>{{vedlegg}}</p>
+                        </li>
+                    {{/each}}
+                </ul>
+            {{/if}}
+        {{/if}}
+
         {{#if barn.manglerNorskIdentitetsnummer}}
             <h2>Fødselsattest</h2>
             {{#if harLastetOppFødselsattest}}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/EttersendingAvVedleggTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/EttersendingAvVedleggTest.kt
@@ -1,0 +1,52 @@
+package no.nav.brukerdialog.ytelse.opplæringspenger.api.k9Format
+
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.EttersendingAvVedlegg
+import no.nav.brukerdialog.ytelse.opplæringspenger.api.domene.VedleggType
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EttersendingAvVedleggTest {
+    private val validator: Validator = Validation.buildDefaultValidatorFactory().validator
+
+    @Test
+    fun `gir ingen feil når skalEttersendeVedlegg er true og vedleggSomSkalEttersendes ikke er tomt`() {
+        val ettersending = EttersendingAvVedlegg(
+            skalEttersendeVedlegg = true,
+            vedleggSomSkalEttersendes = listOf(VedleggType.LEGEERKLÆRING)
+        )
+
+        val violations = validator.validate(ettersending)
+        assertTrue(violations.isEmpty())
+    }
+
+    @Test
+    fun `gir feil når skalEttersendeVedlegg er true og vedleggSomSkalEttersendes er tomt`() {
+        val ettersending = EttersendingAvVedlegg(
+            skalEttersendeVedlegg = true,
+            vedleggSomSkalEttersendes = listOf()
+        )
+
+        val violations = validator.validate(ettersending)
+        assertFalse(violations.isEmpty())
+        assertTrue(violations.size == 1)
+        assertTrue((violations.all { it.message.contains("Vedlegg som skal ettersendes kan ikke være tomt når skalEttersendeVedlegg er true.") }))
+
+    }
+
+    @Test
+    fun `gir feil når skalEttersendeVedlegg er true og vedleggSomSkalEttersendes er null`() {
+        val ettersending = EttersendingAvVedlegg(
+            skalEttersendeVedlegg = true,
+            vedleggSomSkalEttersendes = null
+        )
+
+        val violations = validator.validate(ettersending)
+        assertFalse(violations.isEmpty())
+        assertTrue(violations.size == 1)
+        assertTrue((violations.all { it.message.contains("Vedlegg som skal ettersendes kan ikke være tomt når skalEttersendeVedlegg er true.") }))
+
+    }
+}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/OpplæringspengerSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/OpplæringspengerSøknadKonsumentTest.kt
@@ -19,7 +19,6 @@ import org.intellij.lang.annotations.Language
 import org.json.JSONObject
 import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
-import java.net.URI
 import java.time.ZonedDateTime
 import java.util.*
 
@@ -374,6 +373,13 @@ class OpplæringspengerSøknadKonsumentTest : AbstractIntegrationTest() {
                 }
               ],
               "skalTaUtFerieIPerioden": true
+            },
+            "ettersendingAvVedlegg": {
+              "skalEttersendeVedlegg": true,
+              "vedleggSomSkalEttersendes": [
+                "LEGEERKLÆRING",
+                "KURSINFORMASJON"
+              ]
             },
             "frilans": {
                 "harHattInntektSomFrilanser": true,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfGeneratorTest.kt
@@ -313,6 +313,17 @@ class OLPSøknadPdfGeneratorTest {
                 ).pdfData()
             )
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+            id = "19-uten-skal-ettersende-vedlegg"
+            pdf = generator.genererPDF(
+                pdfData = OlpPdfSøknadUtils.gyldigSøknad(id).copy(
+                    ettersendingAvVedlegg = EttersendingAvVedlegg(
+                        skalEttersendeVedlegg = false,
+                        vedleggSomSkalEttersendes = null
+                    )
+                ).pdfData()
+            )
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
         }
     }
 }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
@@ -155,6 +155,10 @@ object OlpPdfSøknadUtils {
             ),
             harVærtEllerErVernepliktig = true,
             k9FormatSøknad = K9FormatUtils.defaultK9FormatPSB(soknadsId, mottatt),
+            ettersendingAvVedlegg = EttersendingAvVedlegg(
+                skalEttersendeVedlegg = true,
+                vedleggSomSkalEttersendes = listOf(VedleggType.LEGEERKLÆRING, VedleggType.KURSINFORMASJON)
+            ),
             kurs = Kurs(
                 kursholder = Kursholder(
                     UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
@@ -169,6 +169,10 @@ class SøknadUtils {
                     tilOgMed = LocalDate.parse("2022-01-10")
                 )
             ),
+            ettersendingAvVedlegg = EttersendingAvVedlegg(
+                skalEttersendeVedlegg = true,
+                vedleggSomSkalEttersendes = listOf(VedleggType.LEGEERKLÆRING)
+            ),
             kurs = Kurs(
                 kursholder = Kursholder(
                     UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi skal spørre søker som hen skal ettersende vedlegg, og i så fall hvilke vedlegg. Informasjonen skal kun inn i PDF enn så lenge.

Jira: https://jira.adeo.no/browse/TSFF-1765

### **Løsning**
- Legger til typen `EttersendingAvVedlegg` og `VedleggType` i søknadene for opplæringspenger 
- Map info om ettersendelse til pdf-en

### **Skjermbilder av søknadspdfen**

| Med skal ettersende vedlegg | Uten skal ettersende vedlegg |
| ----------------------------- | ----------------------------- |
| ![Screenshot 2025-07-07 at 14 14 15](https://github.com/user-attachments/assets/80c82f1a-7260-4351-a9e4-92c9329fd86b) | ![Screenshot 2025-07-07 at 14 14 19](https://github.com/user-attachments/assets/e72d651e-0f84-4d72-8c0c-208e19463d37) |


