### PR TITLE
Grupperer swagger-definisjoenen pr. ytelse.

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/config/SwaggerConfiguration.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
@@ -13,6 +14,105 @@ import org.springframework.http.HttpHeaders
 
 @Configuration
 class SwaggerConfiguration {
+
+    @Bean
+    fun ettersendelseApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("ettersendelse")
+            .displayName("Ettersendelse API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.ettersendelse.api")
+            .build()
+    }
+
+    @Bean
+    fun omsorgspengerUtbetalingAtApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("omsorgspengerutbetaling-arbeidstaker")
+            .displayName("Omsorgspengerutbetaling Arbeidstaker API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgpengerutbetalingat.api")
+            .build()
+    }
+
+    @Bean
+    fun omsorgspengerUtbetalingSnfApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("omsorgspengerutbetaling-snf")
+            .displayName("Omsorgspengerutbetaling Selvstendig Næringsdrivende / Frilanser API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgpengerutbetalingsnf.api")
+            .build()
+    }
+
+    @Bean
+    fun omsorgspengerAleneomsorgApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("omsorgspenger-aleneomsorg")
+            .displayName("Omsorgspenger Aleneomsorg API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgspengeraleneomsorg.api")
+            .build()
+    }
+
+    @Bean
+    fun omsorgspengerKroniskSyktBarnApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("omsorgspenger-kronisk-sykt-barn")
+            .displayName("Omsorgspenger Kronisk Sykt Barn API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgspengerkronisksyktbarn.api")
+            .build()
+    }
+
+    @Bean
+    fun omsorgspengerMidlertidigAleneApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("omsorgspenger-midlertidig-alene")
+            .displayName("Omsorgspenger Midlertidig Alene API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgspengermidlertidigalene.api")
+            .build()
+    }
+
+    @Bean
+    fun opplaeringspengerApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("opplaeringspenger")
+            .displayName("Opplæringspenger API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.opplæringspenger.api")
+            .build()
+    }
+
+    @Bean
+    fun pleiepengerLivetsSluttfaseApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("pleiepenger-livets-sluttfase")
+            .displayName("Pleiepenger Livets Sluttfase API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.pleiepengerilivetssluttfase.api")
+            .build()
+    }
+
+    @Bean
+    fun pleiepengerSyktBarnSoknadApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("pleiepenger-sykt-barn-soknad")
+            .displayName("Pleiepenger Sykt Barn Søknad API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.api")
+            .build()
+    }
+
+    @Bean
+    fun pleiepengerSyktBarnEndringsmeldingApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("pleiepenger-sykt-barn-endringsmelding")
+            .displayName("Pleiepenger Sykt Barn Endringsmelding API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.pleiepengersyktbarn.endringsmelding.api")
+            .build()
+    }
+
+    @Bean
+    fun ungdomsytelseApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("ungdomsytelse")
+            .displayName("Ungdomsytelse API")
+            .packagesToScan("no.nav.brukerdialog.ytelse.ungdomsytelse.api")
+            .build()
+    }
 
     @Bean
     fun openAPI(): OpenAPI {

--- a/src/main/kotlin/no/nav/brukerdialog/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/config/SwaggerConfiguration.kt
@@ -14,13 +14,19 @@ import org.springframework.http.HttpHeaders
 
 @Configuration
 class SwaggerConfiguration {
+    private companion object {
+        private val FELLES_PAKKER = arrayOf(
+            "no.nav.brukerdialog.oppslag",
+            "no.nav.brukerdialog.mellomlagring"
+        )
+    }
 
     @Bean
     fun ettersendelseApi(): GroupedOpenApi {
         return GroupedOpenApi.builder()
             .group("ettersendelse")
             .displayName("Ettersendelse API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.ettersendelse.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.ettersendelse.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -29,7 +35,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("omsorgspengerutbetaling-arbeidstaker")
             .displayName("Omsorgspengerutbetaling Arbeidstaker API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgpengerutbetalingat.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgpengerutbetalingat.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -38,7 +44,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("omsorgspengerutbetaling-snf")
             .displayName("Omsorgspengerutbetaling Selvstendig Næringsdrivende / Frilanser API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgpengerutbetalingsnf.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgpengerutbetalingsnf.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -47,7 +53,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("omsorgspenger-aleneomsorg")
             .displayName("Omsorgspenger Aleneomsorg API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgspengeraleneomsorg.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgspengeraleneomsorg.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -56,7 +62,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("omsorgspenger-kronisk-sykt-barn")
             .displayName("Omsorgspenger Kronisk Sykt Barn API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgspengerkronisksyktbarn.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgspengerkronisksyktbarn.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -65,7 +71,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("omsorgspenger-midlertidig-alene")
             .displayName("Omsorgspenger Midlertidig Alene API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgspengermidlertidigalene.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.omsorgspengermidlertidigalene.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -74,7 +80,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("opplaeringspenger")
             .displayName("Opplæringspenger API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.opplæringspenger.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.opplæringspenger.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -83,7 +89,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("pleiepenger-livets-sluttfase")
             .displayName("Pleiepenger Livets Sluttfase API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.pleiepengerilivetssluttfase.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.pleiepengerilivetssluttfase.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -92,7 +98,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("pleiepenger-sykt-barn-soknad")
             .displayName("Pleiepenger Sykt Barn Søknad API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.pleiepengersyktbarn.søknad.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -101,7 +107,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("pleiepenger-sykt-barn-endringsmelding")
             .displayName("Pleiepenger Sykt Barn Endringsmelding API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.pleiepengersyktbarn.endringsmelding.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.pleiepengersyktbarn.endringsmelding.api", *FELLES_PAKKER)
             .build()
     }
 
@@ -110,7 +116,7 @@ class SwaggerConfiguration {
         return GroupedOpenApi.builder()
             .group("ungdomsytelse")
             .displayName("Ungdomsytelse API")
-            .packagesToScan("no.nav.brukerdialog.ytelse.ungdomsytelse.api")
+            .packagesToScan("no.nav.brukerdialog.ytelse.ungdomsytelse.api", *FELLES_PAKKER)
             .build()
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -298,4 +298,4 @@ springdoc:
     disable-swagger-default-url: true
     path: swagger-ui.html
   # Setter for å skille på klasser/skjemaer med samme navn. Inkluderer pakkenavn i navnet på skjemaet.
-  use-fqn: true
+  #use-fqn: true


### PR DESCRIPTION
### **Behov / Bakgrunn**
Bruk av pakkenavn for å skille på swagger definisjonene ga unødvendig lange navn når frontend generer klassene basert på de.

### **Løsning**
Splitter API-ene pr. ytelse slik at felles klasser som brukes i flere søknader ikke blir et problem.
Fjerner dermed use-fqn=true. Default er false.

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
