### PR TITLE
UNG - Håndterer manglende kontonummeropplysninger i søknads-pdf.

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelsesøknadPdfData.kt
@@ -31,7 +31,8 @@ class UngdomsytelsesøknadPdfData(private val søknad: UngdomsytelsesøknadMotta
         ),
         "kontonummer" to mapOf(
             "kontonummerErRiktig" to søknad.kontonummerErRiktig,
-            "kontonummerFraRegister" to søknad.kontonummerFraRegister
+            "kontonummerFraRegister" to søknad.kontonummerFraRegister,
+            "viVetIkke" to (søknad.kontonummerErRiktig == null && søknad.kontonummerFraRegister == null),
         ),
         "samtykke" to mapOf(
             "harForståttRettigheterOgPlikter" to søknad.harForståttRettigheterOgPlikter,

--- a/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-soknad.hbs
@@ -35,11 +35,16 @@
 
     <section id="kontonummer">
         <h2>Kontonummer for utbetaling</h2>
-        {{#if kontonummer.kontonummerFraRegister}}
-            <p class="sporsmalstekst">Stemmer det at kontonummeret ditt er {{kontonummer.kontonummerFraRegister}}?</p>
-            <p>{{ jaNeiSvar kontonummer.kontonummerErRiktig }}</p>
+        {{#if kontonummer.viVetIkke}}
+            <p>Vi klarer ikke å se om du har registrert kontonummer hos oss.</p>
+
         {{else}}
-            <p>Vi har ikke registrert kontonummer på deg.</p>
+            {{#if kontonummer.kontonummerFraRegister}}
+                <p class="sporsmalstekst">Stemmer det at kontonummeret ditt er {{kontonummer.kontonummerFraRegister}}?</p>
+                <p>{{ jaNeiSvar kontonummer.kontonummerErRiktig }}</p>
+            {{else}}
+                <p>Vi har ikke registrert kontonummer på deg.</p>
+            {{/if}}
         {{/if}}
     </section>
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
For å ikke forhindre deltaker i å søke når oppslag av kontonummer feiler, er det ønskelig å vise det i PDF-en at vi ikke har klart å utlede det.

### **Løsning**
Dersom både `kontonummerFraRegister` og `kontonummerErRiktig` er `null` tolker vi det som at oppslaget har feilet og ingen spørsmål om kontonummer er presentert deltaker.

Dersom det er tilfelle viser vi `Vi klarer ikke å se om du har registrert kontonummer hos oss`.
