### PR TITLE
TSFF-1903: Oppdater k9-kontrakt for å ettersende kursinformasjon

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ repositories {
 
 val tokenSupportVersion = "5.0.33"
 val jsonassertVersion = "1.5.3"
-val k9FormatVersion = "12.5.2"
+val k9FormatVersion = "12.5.4"
 val ungDeltakelseOpplyserVersjon = "2.4.0"
 val springMockkVersion = "4.0.2"
 val logstashLogbackEncoderVersion = "8.1"


### PR DESCRIPTION
### **Behov / Bakgrunn**
For å ettersende kursinformasjon direkte til en sak i k9-sak, må bruke oppdatert kontrakt med `KURSINFORMASJON`.

### **Løsning**
Bump k9-format