### PR TITLE
TSFF-1913: Fjern sluttetFørSøknadsperiode og vis alltid normal arbeidstid i pdfen for opplæringspenger

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/arbeid/ArbeidsgiverOLP.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/domene/arbeid/ArbeidsgiverOLP.kt
@@ -17,7 +17,6 @@ data class ArbeidsgiverOLP(
     @field:NotBlank(message = "navn kan ikke være tomt eller blankt")
     private val navn: String,
     private val erAnsatt: Boolean,
-    private val sluttetFørSøknadsperiode: Boolean? = null,
 
     @field:Valid
     private val arbeidsforhold: ArbeidsforholdOLP? = null,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Arbeid.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/domene/felles/Arbeid.kt
@@ -7,7 +7,6 @@ data class Arbeidsgiver(
     val navn: String? = null,
     val organisasjonsnummer: String,
     val erAnsatt: Boolean,
-    val sluttetFørSøknadsperiode: Boolean? = null,
     val arbeidsforhold: Arbeidsforhold? = null
 )
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/pdf/OLPSøknadPdfData.kt
@@ -218,8 +218,6 @@ class OLPSøknadPdfData(private val søknad: OLPMottattSøknad) : PdfData() {
             "organisasjonsnummer" to it.organisasjonsnummer,
             "erAnsatt" to it.erAnsatt,
             "arbeidsforhold" to it.arbeidsforhold?.somMap(),
-            "sluttetFørSøknadsperiodeErSatt" to (it.sluttetFørSøknadsperiode != null),
-            "sluttetFørSøknadsperiode" to it.sluttetFørSøknadsperiode
         )
     }
 

--- a/src/main/resources/handlebars/opplaeringspenger-soknad.hbs
+++ b/src/main/resources/handlebars/opplaeringspenger-soknad.hbs
@@ -138,18 +138,14 @@
                         <ul>
                             {{#if arbeidsgiver.erAnsatt}}
                                 <li>Er ansatt i perioden det søkes for</li>
+                                {{#if arbeidsgiver.arbeidsforhold}}
+                                    <li>Jobber normalt {{arbeidsgiver.arbeidsforhold.jobberNormaltTimer}} timer per uke</li>
+                                {{/if}}
                             {{else}}
                                 <li>Er ikke ansatt i perioden det søkes for</li>
-                                {{#if arbeidsgiver.sluttetFørSøknadsperiodeErSatt}}
-                                    <li>
-                                        <p>Sluttet du hos {{arbeidsgiver.navn}} før {{periode.fra_og_med}}?</p>
-                                        <p>{{ jaNeiSvar arbeidsgiver.sluttetFørSøknadsperiode }}</p>
-                                    </li>
+                                {{#if arbeidsgiver.arbeidsforhold}}
+                                    <li>Jobbet normalt {{arbeidsgiver.arbeidsforhold.jobberNormaltTimer}} timer per uke</li>
                                 {{/if}}
-                            {{/if}}
-                            {{#if arbeidsgiver.arbeidsforhold}}
-                                <li>Jobber normalt {{arbeidsgiver.arbeidsforhold.jobberNormaltTimer}} timer per uke
-                                </li>
                             {{/if}}
                         </ul>
                     </li>

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/ArbeidsgiverOLPTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/ArbeidsgiverOLPTest.kt
@@ -22,7 +22,6 @@ class ArbeidsgiverOLPTest {
                 navn = "Fiskeriet AS",
                 organisasjonsnummer = "991346066",
                 erAnsatt = true,
-                sluttetFørSøknadsperiode = false,
                 arbeidsforhold = ArbeidsforholdOLP(
                     37.5,
                     ArbeidIPeriode(JobberIPeriodeSvar.SOM_VANLIG, enkeltDagerMedJobbSomVanlig)
@@ -38,7 +37,6 @@ class ArbeidsgiverOLPTest {
                 navn = " ",
                 organisasjonsnummer = "991346066",
                 erAnsatt = true,
-                sluttetFørSøknadsperiode = false,
                 arbeidsforhold = ArbeidsforholdOLP(
                     37.5,
                     ArbeidIPeriode(JobberIPeriodeSvar.HELT_FRAVÆR, enkeltDagerMedFulltFravær)
@@ -54,7 +52,6 @@ class ArbeidsgiverOLPTest {
                 navn = "Fiskeriet AS",
                 organisasjonsnummer = "991346066",
                 erAnsatt = true,
-                sluttetFørSøknadsperiode = false,
                 arbeidsforhold = ArbeidsforholdOLP(37.5, ArbeidIPeriode(JobberIPeriodeSvar.REDUSERT, emptyList()))
             ),
             1,
@@ -69,7 +66,6 @@ class ArbeidsgiverOLPTest {
                 navn = "Fiskeriet AS",
                 organisasjonsnummer = "1ABC",
                 erAnsatt = true,
-                sluttetFørSøknadsperiode = false,
                 arbeidsforhold = ArbeidsforholdOLP(
                     37.5, ArbeidIPeriode(
                         JobberIPeriodeSvar.HELT_FRAVÆR,
@@ -88,7 +84,6 @@ class ArbeidsgiverOLPTest {
             navn = "Fiskeriet AS",
             organisasjonsnummer = "991346066",
             erAnsatt = true,
-            sluttetFørSøknadsperiode = false,
             arbeidsforhold = ArbeidsforholdOLP(
                 37.5, ArbeidIPeriode(
                     JobberIPeriodeSvar.HELT_FRAVÆR, listOf(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/OpplæringspengerSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/OpplæringspengerSøknadKonsumentTest.kt
@@ -480,14 +480,12 @@ class OpplæringspengerSøknadKonsumentTest : AbstractIntegrationTest() {
                   "jobberNormaltTimer": 40
                 },
                 "navn": "Arbeidsplassen AS",
-                "sluttetFørSøknadsperiode": null,
                 "organisasjonsnummer": "917755736"
               },
               {
                 "erAnsatt": false,
                 "arbeidsforhold": null,
                 "navn": "JobberIkkeHerLenger AS",
-                "sluttetFørSøknadsperiode": false,
                 "organisasjonsnummer": "977155436"
               }
             ],

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
@@ -105,8 +105,7 @@ object OlpPdfSøknadUtils {
                 ), Arbeidsgiver(
                     navn = "JobberIkkeHerLenger AS",
                     organisasjonsnummer = "977155436",
-                    erAnsatt = false,
-                    sluttetFørSøknadsperiode = false
+                    erAnsatt = false
                 )
             ),
             frilans = Frilans(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
@@ -67,8 +67,7 @@ class SøknadUtils {
                 ArbeidsgiverOLP(
                     navn = "JobberIkkeHerLenger",
                     organisasjonsnummer = "977155436",
-                    erAnsatt = false,
-                    sluttetFørSøknadsperiode = false
+                    erAnsatt = false
                 )
             ),
             frilans = FrilansOLP(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SerDesTest.kt
@@ -79,6 +79,7 @@ internal class SerDesTest {
                   "navn": "Org",
                   "organisasjonsnummer": "917755736",
                   "erAnsatt": true,
+                  "sluttetFørSøknadsperiode": null,
                   "arbeidsforhold": {
                     "normalarbeidstid": {
                       "timerPerUkeISnitt": "PT37H30M"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SerDesTest.kt
@@ -79,7 +79,6 @@ internal class SerDesTest {
                   "navn": "Org",
                   "organisasjonsnummer": "917755736",
                   "erAnsatt": true,
-                  "sluttetFørSøknadsperiode": null,
                   "arbeidsforhold": {
                     "normalarbeidstid": {
                       "timerPerUkeISnitt": "PT37H30M"


### PR DESCRIPTION
### **Behov / Bakgrunn**
Oppsummeringen må oppdateres til å alltid vise normalarbeidstid, uavhengig av om en er ansatt eller ikke. Spørsmålet om en sluttet før søknadsperioden er tatt bort, så denne må også fjernes fra oppsummeringen.

Jira: https://jira.adeo.no/browse/TSFF-1913

### **Løsning**
- Fjerner sluttetFørSøknadsperiode.
- mapper alltid ut normal arbeidstid uansett om erAnsatt er true eller false. 

### Todo
Gjør ArbeidsforholdOLP påkrevd for opplæringspenger slik at vi alltid får inn normal arbeidstid. Må gjøres etter at vi har rensket opp i mellomlagring