### PR TITLE
Add deploy workflow for aktivitetspenger inntektsrapportering topics

### DIFF
--- a/.github/workflows/deploy-aktivitetspenger-inntektsrapportering-topics.yml
+++ b/.github/workflows/deploy-aktivitetspenger-inntektsrapportering-topics.yml
@@ -1,0 +1,21 @@
+name: Deploy aktivitetspenger inntektsrapportering topics
+
+env:
+  TOPICS_PATH: 'nais/topics/aktivitetspenger-inntektsrapportering-topics.yml'
+
+on:
+  push:
+    paths:
+      - '.github/workflows/deploy-aktivitetspenger-inntektsrapportering-topics.yml'
+      - '.github/workflows/reusable-topic-workflow.yml'
+      - 'nais/topics/aktivitetspenger-inntektsrapportering-topics.yml'
+
+jobs:
+  deploy-aktivitetspenger-inntektsrapportering-topics:
+    permissions:
+      id-token: write
+    uses: ./.github/workflows/reusable-topic-workflow.yml
+    with:
+      job-name: aktivitetspenger-inntektsrapportering-topics
+      topics-path: 'nais/topics/aktivitetspenger-inntektsrapportering-topics.yml'
+    secrets: inherit


### PR DESCRIPTION
## Summary
Add the missing GitHub Actions workflow for deploying `nais/topics/aktivitetspenger-inntektsrapportering-topics.yml`.

## Why
The latest aktivitetspenger inntektsrapportering change added Kafka Streams consumers for the new source topics, but this repo deploys topic manifests through dedicated workflows. Without a matching workflow, the app can be deployed before those topics exist, which leads to Kafka Streams startup failures such as "One or more source topics were missing during rebalance".

## Change
- add `.github/workflows/deploy-aktivitetspenger-inntektsrapportering-topics.yml`
- wire it to the shared reusable topic workflow
- trigger deployment when the new topic manifest or reusable workflow changes
