### PR TITLE
Fiks: downgrade spring boot og pin tomcat versjon

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "4.0.5"
+	id("org.springframework.boot") version "4.0.3"
 	id("io.spring.dependency-management") version "1.1.7"
 	kotlin("jvm") version "2.3.20"
 	kotlin("plugin.spring") version "2.3.20"
@@ -12,6 +12,8 @@ plugins {
 group = "no.nav"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_25
+
+extra["tomcat.version"] = "11.0.21"
 
 configurations {
 	compileOnly {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ny patch-versjon av spring boot  fikser kritisk sårbarhet i tomcat, men drar med seg en endring som gjør at vi bruker jackson 3 i stedet for jackson 2, som feiler. 

### **Løsning**
Downgrader spring boot og pinner tomcat versjon som fikser kritisk sårbarhet