### PR TITLE
Håndter MultipartException fra klient-avbrudd som WARN i stedet for ERROR

### DIFF
--- a/nais/alerts.yml
+++ b/nais/alerts.yml
@@ -90,7 +90,7 @@ spec:
             severity: critical
 
         - alert: Høy andel HTTP klientfeil (4xx responser)
-          expr: floor(increase(http_server_requests_seconds_count{status=~"4.*", status!~"404|401|403", app="{{app}}"}[3m])) > 0
+          expr: floor(increase(http_server_requests_seconds_count{status=~"4.*", status!~"404|401|403|418", app="{{app}}"}[3m])) > 0
           for: 1m
           annotations:
             summary: "Følgende request feilet: `Status \{{ $labels.status }} - \{{ $labels.method }} \{{ $labels.uri }}`.\n

--- a/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
@@ -54,7 +54,7 @@ class ExceptionHandler(
                 type = URI("/problem-details/multipart-feil"),
                 detail = exception.message ?: ""
             )
-            log.warn("Klient avbrøt multipart-opplasting: {}", problemDetails)
+            log.warn("Klient avbrøt multipart-opplasting: {}", problemDetails, exception)
             return problemDetails
         }
 

--- a/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
@@ -48,6 +48,7 @@ class ExceptionHandler(
             .any { it::class.qualifiedName == "org.apache.catalina.connector.ClientAbortException" || it is java.io.EOFException }
 
         if (isClientAbort) {
+            // kaster feil med statuskode 418 I'm a teapot, slik at vi kan filtrere ut feilen i alarmkanalen
             val problemDetails = request.respondProblemDetails(
                 status = I_AM_A_TEAPOT,
                 title = "Bruker avbrøt opplasting av vedlegg",

--- a/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
@@ -47,18 +47,24 @@ class ExceptionHandler(
         val isClientAbort = generateSequence(exception as Throwable) { it.cause }
             .any { it::class.qualifiedName == "org.apache.catalina.connector.ClientAbortException" || it is java.io.EOFException }
 
+        if (isClientAbort) {
+            val problemDetails = request.respondProblemDetails(
+                status = I_AM_A_TEAPOT,
+                title = "Bruker avbrøt opplasting av vedlegg",
+                type = URI("/problem-details/multipart-feil"),
+                detail = exception.message ?: ""
+            )
+            log.warn("Klient avbrøt multipart-opplasting: {}", problemDetails)
+            return problemDetails
+        }
+
         val problemDetails = request.respondProblemDetails(
             status = BAD_REQUEST,
             title = "Feil ved opplasting av vedlegg",
             type = URI("/problem-details/multipart-feil"),
             detail = exception.message ?: ""
         )
-
-        if (isClientAbort) {
-            log.warn("Klient avbrøt multipart-opplasting: {}", problemDetails)
-        } else {
-            log.error("{}", problemDetails, exception)
-        }
+        log.error("{}", problemDetails, exception)
 
         return problemDetails
     }

--- a/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.multipart.MaxUploadSizeExceededException
+import org.springframework.web.multipart.MultipartException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import java.net.URI
 import java.net.URLDecoder
@@ -39,6 +40,28 @@ class ExceptionHandler(
             LoggerFactory.getLogger(no.nav.brukerdialog.http.serverside.ExceptionHandler::class.java)
     }
 
+
+    @ExceptionHandler(value = [MultipartException::class])
+    @ResponseStatus(BAD_REQUEST)
+    fun håndtereMultipartException(exception: MultipartException, request: ServletWebRequest): ProblemDetail {
+        val isClientAbort = generateSequence(exception as Throwable) { it.cause }
+            .any { it::class.qualifiedName == "org.apache.catalina.connector.ClientAbortException" || it is java.io.EOFException }
+
+        val problemDetails = request.respondProblemDetails(
+            status = BAD_REQUEST,
+            title = "Feil ved opplasting av vedlegg",
+            type = URI("/problem-details/multipart-feil"),
+            detail = exception.message ?: ""
+        )
+
+        if (isClientAbort) {
+            log.warn("Klient avbrøt multipart-opplasting: {}", problemDetails)
+        } else {
+            log.error("{}", problemDetails, exception)
+        }
+
+        return problemDetails
+    }
 
     @ExceptionHandler(value = [Exception::class])
     @ResponseStatus(INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
### **Behov / Bakgrunn**
Klienter som avbryter vedleggsopplasting (lukker nettleser/tab, mister nett)
forårsaket ClientAbortException/EOFException som ble fanget av den generiske
exception-handleren og logget som ERROR med full stacktrace. Dette ga falske
alarmer i feilloggene.

### **Løsning**
Legger til dedikert @ExceptionHandler for MultipartException som:
- Traverserer cause-kjeden for å identifisere klient-avbrudd
- Ved klient-avbrudd --> Logger på WARN-nivå og returner 418 – Im a teapot for filtrering i alert-manager
- Hvis ikke klient-avbrudd --> Logger på ERROR-nivå og returner 400 Bad Request 
- Filtrer ut statuskode 418 i `alerts.yml` så vi slipper støy i alarmkanalen
