### PR TITLE
Fiks: returner 418 hvis bruker avbryter opplasting av vedlegg

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/http/serverside/ExceptionHandler.kt
@@ -42,8 +42,7 @@ class ExceptionHandler(
 
 
     @ExceptionHandler(value = [MultipartException::class])
-    @ResponseStatus(BAD_REQUEST)
-    fun håndtereMultipartException(exception: MultipartException, request: ServletWebRequest): ProblemDetail {
+    fun håndtereMultipartException(exception: MultipartException, request: ServletWebRequest): ResponseEntity<ProblemDetail> {
         val isClientAbort = generateSequence(exception as Throwable) { it.cause }
             .any { it::class.qualifiedName == "org.apache.catalina.connector.ClientAbortException" || it is java.io.EOFException }
 
@@ -55,8 +54,8 @@ class ExceptionHandler(
                 type = URI("/problem-details/multipart-feil"),
                 detail = exception.message ?: ""
             )
-            log.warn("Klient avbrøt multipart-opplasting: {}", problemDetails, exception)
-            return problemDetails
+            log.info("Klient avbrøt multipart-opplasting: {}", problemDetails, exception)
+            return ResponseEntity.status(I_AM_A_TEAPOT).body(problemDetails)
         }
 
         val problemDetails = request.respondProblemDetails(
@@ -67,7 +66,7 @@ class ExceptionHandler(
         )
         log.error("{}", problemDetails, exception)
 
-        return problemDetails
+        return ResponseEntity.status(BAD_REQUEST).body(problemDetails)
     }
 
     @ExceptionHandler(value = [Exception::class])


### PR DESCRIPTION
### **Behov / Bakgrunn**
@ResponseStatus(BAD_REQUEST) overstyrte statuskoden i ProblemDetail-bodyen,
så vi registrerte 400 i stedet for 418. Dermed ble ikke klientavbrudd
filtrert ut av "Høy andel HTTP klientfeil (4xx responser)"-alarmen.

### **Løsning**
- Fjernet @ResponseStatus(BAD_REQUEST) fra håndtereMultipartException
- Endret returtype til ResponseEntity<ProblemDetail> for eksplisitt statuskontroll
- Endret log.warn til log.info for klientavbrudd for å unngå "Høy andel warning"-alarm
