### PR TITLE
Erstatter ikke-godkjente fødselsnummer med fiktive FNR fra godkjent liste

### DIFF
--- a/src/test/kotlin/no/nav/brukerdialog/AbstractIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/AbstractIntegrationTest.kt
@@ -161,7 +161,7 @@ abstract class AbstractIntegrationTest {
         )
     }
 
-    protected fun mockSøker(aktørId: String = "1234", fnr: String = "02119970078"): Søker {
+    protected fun mockSøker(aktørId: String = "1234", fnr: String = "01017000299"): Søker {
         val søker = Søker(
             aktørId = aktørId,
             fødselsdato = LocalDate.parse("1999-11-02"),

--- a/src/test/kotlin/no/nav/brukerdialog/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/utils/SøknadUtils.kt
@@ -21,7 +21,7 @@ class SøknadUtils {
             fødselsdato = LocalDate.parse("1999-11-02"),
             fornavn = "MOR",
             etternavn = "MORSEN",
-            fødselsnummer = "02119970078"
+            fødselsnummer = "01017000299"
         )
 
         val metadata = MetaInfo(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengerInntektRapporteringKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengerInntektRapporteringKonsumentTest.kt
@@ -153,7 +153,7 @@ class AktivitetspengerInntektRapporteringKonsumentTest : AbstractIntegrationTest
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "oppgittInntektForPeriode": {
                 "arbeidstakerOgFrilansInntekt": 6000,
@@ -174,7 +174,7 @@ class AktivitetspengerInntektRapporteringKonsumentTest : AbstractIntegrationTest
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "02119970078"
+              "norskIdentitetsnummer": "01017000299"
             },
             "ytelse": {
               "type": "AKTIVITETSPENGER",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengersøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengersøknadKonsumentTest.kt
@@ -132,7 +132,7 @@ class AktivitetspengersøknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "startdato": "2022-01-01",
           "barn": [
@@ -161,7 +161,7 @@ class AktivitetspengersøknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "02119970078"
+              "norskIdentitetsnummer": "01017000299"
             },
             "ytelse": {
               "type": "AKTIVITETSPENGER",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengerOppgavebekreftelseUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengerOppgavebekreftelseUtils.kt
@@ -47,7 +47,7 @@ object AktivitetspengerOppgavebekreftelseUtils {
     )
 
     fun oppgavebekreftelseMottatt(
-        søkerFødselsnummer: String = "02119970078",
+        søkerFødselsnummer: String = "01017000299",
         oppgaveReferanse: String = UUID.randomUUID().toString(),
         oppgave: KomplettAktivitetspengerOppgaveDTO = defaultKomplettOppgave.copy(
             oppgaveReferanse = oppgaveReferanse
@@ -79,7 +79,7 @@ object AktivitetspengerOppgavebekreftelseUtils {
             .medSøknadId(søknadId)
             .medVersjon("1.0.0")
             .medMottattDato(mottatt)
-            .medSøker(K9Søker(NorskIdentitetsnummer.of("02119970078")))
+            .medSøker(K9Søker(NorskIdentitetsnummer.of("01017000299")))
             .medBekreftelse(bekreftelse)
             .medKildesystem(Kildesystem.SØKNADSDIALOG)
     }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengersøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengersøknadUtils.kt
@@ -20,7 +20,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 object AktivitetspengersøknadUtils {
 
     fun gyldigSøknad(
-        søkerFødselsnummer: String = "02119970078",
+        søkerFødselsnummer: String = "01017000299",
         søknadId: String = UUID.randomUUID().toString(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
     ): AktivitetspengersøknadMottatt {
@@ -81,7 +81,7 @@ object AktivitetspengersøknadUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("02119970078")),
+            K9Søker(NorskIdentitetsnummer.of("01017000299")),
             ytelse
         ).medKildesystem(Kildesystem.SØKNADSDIALOG)
         return søknad

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/InntektrapporteringUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/InntektrapporteringUtils.kt
@@ -28,7 +28,7 @@ object InntektrapporteringUtils {
     )
 
     fun gyldigInntektsrapportering(
-        søkerFødselsnummer: String = "02119970078",
+        søkerFødselsnummer: String = "01017000299",
         søknadId: String = UUID.randomUUID().toString(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
         oppgittInntektForPeriode: OppgittInntektForPeriode = OppgittInntektForPeriode(
@@ -69,7 +69,7 @@ object InntektrapporteringUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("02119970078")),
+            K9Søker(NorskIdentitetsnummer.of("01017000299")),
             ytelse
 
         ).medKildesystem(Kildesystem.SØKNADSDIALOG)

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/EttersendingSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/EttersendingSøknadTest.kt
@@ -22,11 +22,11 @@ class EttersendingSøknadTest {
               "versjon": "0.0.1",
               "mottattDato": "2020-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "02119970078"
+                "norskIdentitetsnummer": "01017000299"
               },
               "type": "LEGEERKLÆRING",
               "pleietrengende": {
-                "norskIdentitetsnummer": "02119970078"
+                "norskIdentitetsnummer": "01017000299"
               },
               "ytelse": "PLEIEPENGER_LIVETS_SLUTTFASE"
             }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/utils/EttersendelseUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/utils/EttersendelseUtils.kt
@@ -23,7 +23,7 @@ internal object EttersendingUtils {
         søknadstype = no.nav.brukerdialog.ytelse.ettersendelse.api.domene.Søknadstype.PLEIEPENGER_LIVETS_SLUTTFASE,
         beskrivelse = "Pleiepenger .....",
         ettersendelsesType = EttersendelseType.LEGEERKLÆRING,
-        pleietrengende = no.nav.brukerdialog.ytelse.ettersendelse.api.domene.Pleietrengende(norskIdentitetsnummer = "02119970078"),
+        pleietrengende = no.nav.brukerdialog.ytelse.ettersendelse.api.domene.Pleietrengende(norskIdentitetsnummer = "01017000299"),
         harBekreftetOpplysninger = true,
         harForståttRettigheterOgPlikter = true
     )

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/felles/BarnTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/felles/BarnTest.kt
@@ -18,7 +18,7 @@ class BarnTest {
     @Test
     fun `Barn equals test`() {
         val barn = Barn(
-            norskIdentifikator = "02119970078",
+            norskIdentifikator = "01017000299",
             fødselsdato = LocalDate.parse("2022-01-01"),
             aktørId = "12345",
             navn = "Barn Barnesen"
@@ -26,7 +26,7 @@ class BarnTest {
         assertFalse(barn.equals(null))
         assertTrue(
             barn == Barn(
-                norskIdentifikator = "02119970078",
+                norskIdentifikator = "01017000299",
                 fødselsdato = LocalDate.parse("2022-01-01"),
                 aktørId = "12345",
                 navn = "Barn Barnesen"
@@ -43,7 +43,7 @@ class BarnTest {
                 mellomnavn = null,
                 etternavn = "Barnesen",
                 aktørId = "123",
-                identitetsnummer = "02119970078"
+                identitetsnummer = "01017000299"
             )
         )
         val barn = Barn(navn = "Barn uten identifikator", aktørId = "123")
@@ -55,7 +55,7 @@ class BarnTest {
     @Test
     fun `Barn til k9Barn blir som forventet`() {
         val barn = Barn(
-            norskIdentifikator = "02119970078",
+            norskIdentifikator = "01017000299",
             fødselsdato = LocalDate.parse("2022-01-01"),
             aktørId = "12345",
             navn = "Barn Barnesen"
@@ -64,7 +64,7 @@ class BarnTest {
         val forventetK9Barn = JSONObject(
             """
             {
-              "norskIdentitetsnummer": "02119970078",
+              "norskIdentitetsnummer": "01017000299",
               "fødselsdato": null
             }
         """.trimIndent()
@@ -76,7 +76,7 @@ class BarnTest {
     @Test
     fun `Gyldig barn gir ingen valideringsfeil`() {
         Barn(
-            norskIdentifikator = "02119970078",
+            norskIdentifikator = "01017000299",
             navn = "Barnesen"
         ).valider("barn").verifiserIngenValideringsFeil()
     }
@@ -108,7 +108,7 @@ class BarnTest {
     @Test
     fun `Forvent valideringsfeil dersom navn er blank`() {
         Barn(
-            norskIdentifikator = "02119970078",
+            norskIdentifikator = "01017000299",
             navn = " "
         ).valider("barn").verifiserValideringsFeil(1, listOf("barn.navn kan ikke være tomt eller blank."))
     }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneomsorgBarnTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneomsorgBarnTest.kt
@@ -22,7 +22,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 mellomnavn = null,
                 etternavn = "Barnesen",
                 aktørId = "123",
-                identitetsnummer = "02119970078"
+                identitetsnummer = "01017000299"
             )
         )
         val barn = Barn(
@@ -43,12 +43,12 @@ class OmsorgsdagerAleneomsorgBarnTest {
             navn = "Barn uten identifikator",
             type = TypeBarn.FRA_OPPSLAG,
             aktørId = "123",
-            identitetsnummer = "02119970078",
+            identitetsnummer = "01017000299",
             tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
         )
         val forventetK9Barn = """
             {
-              "norskIdentitetsnummer": "02119970078",
+              "norskIdentitetsnummer": "01017000299",
               "fødselsdato": null
             }
         """.trimIndent()
@@ -63,7 +63,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 navn = "Barn uten identifikator",
                 type = TypeBarn.FOSTERBARN,
                 fødselsdato = LocalDate.now().minusMonths(4),
-                identitetsnummer = "02119970078",
+                identitetsnummer = "01017000299",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
             )
         )
@@ -92,7 +92,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 navn = " ",
                 type = TypeBarn.FRA_OPPSLAG,
                 aktørId = "123",
-                identitetsnummer = "02119970078",
+                identitetsnummer = "01017000299",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
             ), 1, "Kan ikke være tomt eller blankt"
         )
@@ -105,7 +105,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 navn = "barnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnb",
                 type = TypeBarn.FRA_OPPSLAG,
                 aktørId = "123",
-                identitetsnummer = "02119970078",
+                identitetsnummer = "01017000299",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
             ), 1, "Kan ikke være mer enn 100 tegn"
         )
@@ -119,7 +119,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 type = TypeBarn.FOSTERBARN,
                 fødselsdato = null,
                 aktørId = "123",
-                identitetsnummer = "02119970078",
+                identitetsnummer = "01017000299",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
             ), 1, "Må være satt når 'type' er annet enn 'FRA_OPPSLAG'"
         )
@@ -132,7 +132,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 navn = "Barnesen",
                 type = TypeBarn.FRA_OPPSLAG,
                 aktørId = "123",
-                identitetsnummer = "02119970078",
+                identitetsnummer = "01017000299",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                 dato = null
             ), 1, "Må være satt når 'tidspunktForAleneomsorg' er 'SISTE_2_ÅRENE'"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneomsorgSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneomsorgSøknadTest.kt
@@ -47,7 +47,7 @@ class OmsorgsdagerAleneomsorgSøknadTest {
                 mellomnavn = null,
                 etternavn = "Barnesen",
                 aktørId = "123",
-                identitetsnummer = "25058118020"
+                identitetsnummer = "01010010001"
             ),
             BarnOppslag(
                 fødselsdato = LocalDate.now(),
@@ -55,7 +55,7 @@ class OmsorgsdagerAleneomsorgSøknadTest {
                 mellomnavn = null,
                 etternavn = "Barnesen",
                 aktørId = "1234",
-                identitetsnummer = "02119970078"
+                identitetsnummer = "01017000299"
             )
         )
         søknad.leggTilIdentifikatorPåBarnHvisMangler(barnFraOppslag)
@@ -106,7 +106,7 @@ class OmsorgsdagerAleneomsorgSøknadTest {
                     navn = "Barn1",
                     type = TypeBarn.FRA_OPPSLAG,
                     aktørId = "123",
-                    identitetsnummer = "25058118020",
+                    identitetsnummer = "01010010001",
                     tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
                 )
             )
@@ -122,12 +122,12 @@ class OmsorgsdagerAleneomsorgSøknadTest {
                   "versjon": "1.0.0",
                   "mottattDato": "2020-01-02T03:04:05Z",
                   "søker": {
-                    "norskIdentitetsnummer": "02119970078"
+                    "norskIdentitetsnummer": "01017000299"
                   },
                   "ytelse": {
                     "type": "OMP_UTV_AO",
                     "barn": {
-                      "norskIdentitetsnummer": "25058118020",
+                      "norskIdentitetsnummer": "01010010001",
                       "fødselsdato": null
                     },
                     "periode": "${fjoråret}-01-01/..",
@@ -182,7 +182,7 @@ class OmsorgsdagerAleneomsorgSøknadTest {
                         type = TypeBarn.FRA_OPPSLAG,
                         fødselsdato = LocalDate.now().plusDays(1),
                         aktørId = "123",
-                        identitetsnummer = "25058118020",
+                        identitetsnummer = "01010010001",
                         tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE,
                         dato = null
                     )

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/kafka/OMPAleneomsorgSoknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/kafka/OMPAleneomsorgSoknadKonsumentTest.kt
@@ -51,7 +51,7 @@ class OMPAleneomsorgSoknadKonsumentTest : AbstractIntegrationTest() {
                         navn = "Barn1",
                         type = TypeBarn.FRA_OPPSLAG,
                         aktørId = "123",
-                        identitetsnummer = "25058118020",
+                        identitetsnummer = "01010010001",
                         tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
                     )
                 )
@@ -125,7 +125,7 @@ class OMPAleneomsorgSoknadKonsumentTest : AbstractIntegrationTest() {
           "mottatt": "$mottatt",
           "språk": "nb",
           "barn": {
-            "identitetsnummer": "29076523302",
+            "identitetsnummer": "01010010002",
             "dato": "2020-08-07",
             "aktørId": "12345",
             "tidspunktForAleneomsorg": "SISTE_2_ÅRENE",
@@ -139,7 +139,7 @@ class OMPAleneomsorgSoknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "1993-01-04",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "harForståttRettigheterOgPlikter": true,
           "dokumentId": [
@@ -155,12 +155,12 @@ class OMPAleneomsorgSoknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "02119970078"
+              "norskIdentitetsnummer": "01017000299"
             },
             "ytelse": {
               "barn": {
                 "fødselsdato": null,
-                "norskIdentitetsnummer": "29076523302"
+                "norskIdentitetsnummer": "01010010002"
               },
               "type": "OMP_UTV_AO",
               "periode": "2020-01-01\/..",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/pdf/OMPAleneomsorgSoknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/pdf/OMPAleneomsorgSoknadPdfGeneratorTest.kt
@@ -46,7 +46,7 @@ class OMPAleneomsorgSoknadPdfGeneratorTest {
             ).copy(
                 barn = Barn(
                     navn = "Ole Dole",
-                    identitetsnummer = "29076523302",
+                    identitetsnummer = "01010010002",
                     type = TypeBarn.FOSTERBARN,
                     fødselsdato = LocalDate.now().minusMonths(5),
                     tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/utils/OMPAleneomsorgSoknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/utils/OMPAleneomsorgSoknadUtils.kt
@@ -17,7 +17,7 @@ import java.time.ZonedDateTime
 internal object OMPAleneomsorgSoknadUtils {
 
     internal fun defaultSøknad(søknadId: String, mottatt: ZonedDateTime): OMPAleneomsorgSoknadMottatt {
-        val søkerFødselsnummer = "02119970078"
+        val søkerFødselsnummer = "01017000299"
         return OMPAleneomsorgSoknadMottatt(
             språk = "nb",
             søknadId = søknadId,
@@ -33,7 +33,7 @@ internal object OMPAleneomsorgSoknadUtils {
             barn = Barn(
                 navn = "Ole Dole",
                 type = TypeBarn.FRA_OPPSLAG,
-                identitetsnummer = "29076523302",
+                identitetsnummer = "01010010002",
                 aktørId = "12345",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                 dato = LocalDate.parse("2020-08-07")
@@ -45,7 +45,7 @@ internal object OMPAleneomsorgSoknadUtils {
                 no.nav.k9.søknad.felles.personopplysninger.Søker(NorskIdentitetsnummer.of(søkerFødselsnummer)),
                 OmsorgspengerAleneOmsorg(
                     no.nav.k9.søknad.felles.personopplysninger.Barn()
-                        .medNorskIdentitetsnummer(NorskIdentitetsnummer.of("29076523302")),
+                        .medNorskIdentitetsnummer(NorskIdentitetsnummer.of("01010010002")),
                     Periode(mottatt.toLocalDate(), null)
                 )
 

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/utils/SøknadUtils.kt
@@ -16,14 +16,14 @@ object SøknadUtils {
                 navn = "Barn1",
                 type = TypeBarn.FRA_OPPSLAG,
                 aktørId = "123",
-                identitetsnummer = "25058118020",
+                identitetsnummer = "01010010001",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
             ),
             Barn(
                 navn = "Barn2",
                 type = TypeBarn.FOSTERBARN,
                 aktørId = "123",
-                identitetsnummer = "25058118020",
+                identitetsnummer = "01010010001",
                 fødselsdato = LocalDate.parse("2024-01-01"),
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                 dato = LocalDate.parse("2022-01-01")

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerUtvidetRettSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerUtvidetRettSøknadTest.kt
@@ -19,7 +19,7 @@ class OmsorgspengerUtvidetRettSøknadTest {
             språk = "nb",
             kroniskEllerFunksjonshemming = true,
             barn = Barn(
-                norskIdentifikator = "02119970078",
+                norskIdentifikator = "01017000299",
                 navn = "Barn Barnesen"
             ),
             relasjonTilBarnet = SøkerBarnRelasjon.FAR,
@@ -71,12 +71,12 @@ class OmsorgspengerUtvidetRettSøknadTest {
                   "mottattDato": "2020-01-02T03:04:05Z",
                   "søknadId": "${søknad.søknadId}",
                   "søker": {
-                    "norskIdentitetsnummer": "02119970078"
+                    "norskIdentitetsnummer": "01017000299"
                   },
                   "ytelse": {
                     "barn": {
                       "fødselsdato": null,
-                      "norskIdentitetsnummer": "02119970078"
+                      "norskIdentitetsnummer": "01017000299"
                     },
                     "kroniskEllerFunksjonshemming": true,
                     "type": "OMP_UTV_KS",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/kafka/OmsorgspengerKroniskSyktBarnSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/kafka/OmsorgspengerKroniskSyktBarnSøknadKonsumentTest.kt
@@ -113,7 +113,7 @@ class OmsorgspengerKroniskSyktBarnSøknadKonsumentTest : AbstractIntegrationTest
             "aktørId": "123456",
             "fødselsdato": "2020-01-01",
             "navn": "Ole Dole Doffen",
-            "norskIdentifikator": "02119970078"
+            "norskIdentifikator": "01017000299"
           },
           "kroniskEllerFunksjonshemming": false,
           "søker": {
@@ -122,7 +122,7 @@ class OmsorgspengerKroniskSyktBarnSøknadKonsumentTest : AbstractIntegrationTest
             "aktørId": "12345",
             "fødselsdato": "2000-01-01",
             "fornavn": "Kjell",
-            "fødselsnummer": "26104500284"
+            "fødselsnummer": "01010010000"
           },
           "harForståttRettigheterOgPlikter": true,
           "dokumentId": [
@@ -148,12 +148,12 @@ class OmsorgspengerKroniskSyktBarnSøknadKonsumentTest : AbstractIntegrationTest
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "26104500284"
+              "norskIdentitetsnummer": "01010010000"
             },
             "ytelse": {
               "barn": {
                 "fødselsdato": null,
-                "norskIdentitetsnummer": "02119970078"
+                "norskIdentitetsnummer": "01017000299"
               },
               "kroniskEllerFunksjonshemming": true,
               "høyereRisikoForFravær": true,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest.kt
@@ -47,7 +47,7 @@ class OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest {
                 fødselsdato = LocalDate.now().minusYears(20)
             ),
             barn = Barn(
-                norskIdentifikator = "02119970078",
+                norskIdentifikator = "01017000299",
                 fødselsdato = LocalDate.now(),
                 aktørId = "123456",
                 navn = "Ole Dole"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/OMPKSSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/OMPKSSøknadUtils.kt
@@ -21,11 +21,11 @@ object OMPKSSøknadUtils {
         fornavn = "Kjell",
         mellomnavn = null,
         etternavn = "Kjeller",
-        fødselsnummer = "26104500284"
+        fødselsnummer = "01010010000"
     )
 
     val barn = Barn(
-        norskIdentifikator = "02119970078",
+        norskIdentifikator = "01017000299",
         navn = "Ole Dole Doffen",
         aktørId = "123456",
         fødselsdato = LocalDate.parse("2020-01-01")
@@ -35,11 +35,11 @@ object OMPKSSøknadUtils {
         Versjon.of("1.0.0"),
         mottatt,
         no.nav.k9.søknad.felles.personopplysninger.Søker(
-            NorskIdentitetsnummer.of("26104500284")
+            NorskIdentitetsnummer.of("01010010000")
         ),
         OmsorgspengerKroniskSyktBarn(
             no.nav.k9.søknad.felles.personopplysninger.Barn()
-                .medNorskIdentitetsnummer(NorskIdentitetsnummer.of("02119970078")),
+                .medNorskIdentitetsnummer(NorskIdentitetsnummer.of("01017000299")),
             true,
             true,
             "Beskrivelse av høyere risiko for fravær"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/SøknadUtils.kt
@@ -12,7 +12,7 @@ internal object SøknadUtils {
         språk = "nb",
         mottatt = ZonedDateTime.parse("2020-01-02T03:04:05.000Z", JacksonConfiguration.zonedDateTimeFormatter),
         barn = Barn(
-            norskIdentifikator = "02119970078",
+            norskIdentifikator = "01017000299",
             fødselsdato = null,
             aktørId = null,
             navn = "Barn Barnsen"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/AnnenForelderTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/AnnenForelderTest.kt
@@ -18,7 +18,7 @@ class AnnenForelderTest {
     fun `AnnenForelder equals test`() {
         val annenForelder = AnnenForelder(
             navn = "Navnesen",
-            fnr = "26104500284",
+            fnr = "01010010000",
             situasjon = Situasjon.FENGSEL,
             periodeFraOgMed = LocalDate.parse("2021-01-01"),
             periodeTilOgMed = LocalDate.parse("2021-08-01")
@@ -27,7 +27,7 @@ class AnnenForelderTest {
             annenForelder.equals(
                 AnnenForelder(
                     navn = "Navnesen",
-                    fnr = "26104500284",
+                    fnr = "01010010000",
                     situasjon = Situasjon.FENGSEL,
                     periodeFraOgMed = LocalDate.parse("2021-01-01"),
                     periodeTilOgMed = LocalDate.parse("2021-08-01")
@@ -41,7 +41,7 @@ class AnnenForelderTest {
     fun `AnnenForelder blir mappet til forventet K9Format`() {
         val faktisk = AnnenForelder(
             navn = "Navnesen",
-            fnr = "26104500284",
+            fnr = "01010010000",
             situasjon = Situasjon.FENGSEL,
             periodeFraOgMed = LocalDate.parse("2021-01-01"),
             periodeTilOgMed = LocalDate.parse("2021-08-01")
@@ -49,7 +49,7 @@ class AnnenForelderTest {
 
         val forventet = """
             {
-              "norskIdentitetsnummer": "26104500284",
+              "norskIdentitetsnummer": "01010010000",
               "situasjon": "FENGSEL",
               "situasjonBeskrivelse": null,
               "periode": "2021-01-01/2021-08-01"
@@ -63,7 +63,7 @@ class AnnenForelderTest {
         Validator.verifiserValideringsFeil(
             AnnenForelder(
                 navn = " ",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.FENGSEL,
                 periodeFraOgMed = LocalDate.parse("2021-01-01"),
                 periodeTilOgMed = LocalDate.parse("2021-08-01")
@@ -92,7 +92,7 @@ class AnnenForelderTest {
         Validator.verifiserValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.FENGSEL,
                 periodeOver6Måneder = true,
                 periodeFraOgMed = LocalDate.parse("2021-01-02"),
@@ -108,7 +108,7 @@ class AnnenForelderTest {
         Validator.verifiserIngenValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.INNLAGT_I_HELSEINSTITUSJON,
                 periodeOver6Måneder = true,
                 periodeFraOgMed = LocalDate.parse("2021-01-01")
@@ -121,7 +121,7 @@ class AnnenForelderTest {
         Validator.verifiserIngenValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.INNLAGT_I_HELSEINSTITUSJON,
                 periodeFraOgMed = LocalDate.parse("2020-01-01"),
                 periodeTilOgMed = LocalDate.parse("2020-07-01")
@@ -134,7 +134,7 @@ class AnnenForelderTest {
         Validator.verifiserValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.INNLAGT_I_HELSEINSTITUSJON,
                 periodeFraOgMed = LocalDate.parse("2020-01-01"),
                 periodeTilOgMed = null,
@@ -150,7 +150,7 @@ class AnnenForelderTest {
         Validator.verifiserIngenValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.FENGSEL,
                 periodeFraOgMed = LocalDate.parse("2020-01-01"),
                 periodeTilOgMed = LocalDate.parse("2021-08-01")
@@ -163,7 +163,7 @@ class AnnenForelderTest {
         Validator.verifiserValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.FENGSEL,
                 periodeFraOgMed = LocalDate.parse("2021-01-01"),
                 periodeTilOgMed = null
@@ -178,7 +178,7 @@ class AnnenForelderTest {
         Validator.verifiserIngenValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.UTØVER_VERNEPLIKT,
                 periodeFraOgMed = LocalDate.parse("2020-01-01"),
                 periodeTilOgMed = LocalDate.parse("2021-08-01")
@@ -191,7 +191,7 @@ class AnnenForelderTest {
         Validator.verifiserValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.UTØVER_VERNEPLIKT,
                 periodeFraOgMed = LocalDate.parse("2021-01-01"),
                 periodeTilOgMed = null
@@ -206,7 +206,7 @@ class AnnenForelderTest {
         Validator.verifiserIngenValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.ANNET,
                 situasjonBeskrivelse = "Blabla noe skjedde",
                 periodeFraOgMed = LocalDate.parse("2021-01-01"),
@@ -220,7 +220,7 @@ class AnnenForelderTest {
         Validator.verifiserValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.ANNET,
                 situasjonBeskrivelse = "",
                 periodeOver6Måneder = true,
@@ -236,7 +236,7 @@ class AnnenForelderTest {
         Validator.verifiserValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.ANNET,
                 situasjonBeskrivelse = "COVID-19",
                 periodeFraOgMed = LocalDate.parse("2021-01-01"),
@@ -253,7 +253,7 @@ class AnnenForelderTest {
         Validator.verifiserIngenValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.SYKDOM,
                 situasjonBeskrivelse = "Blabla noe skjedde",
                 periodeFraOgMed = LocalDate.parse("2021-01-01"),
@@ -267,7 +267,7 @@ class AnnenForelderTest {
         Validator.verifiserValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.SYKDOM,
                 situasjonBeskrivelse = "",
                 periodeOver6Måneder = true,
@@ -283,7 +283,7 @@ class AnnenForelderTest {
         Validator.verifiserValideringsFeil(
             AnnenForelder(
                 navn = "Navnesen",
-                fnr = "26104500284",
+                fnr = "01010010000",
                 situasjon = Situasjon.SYKDOM,
                 situasjonBeskrivelse = "COVID-19",
                 periodeFraOgMed = LocalDate.parse("2021-01-01")

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMidlertidigAleneSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMidlertidigAleneSøknadTest.kt
@@ -30,7 +30,7 @@ class OmsorgspengerMidlertidigAleneSøknadTest {
                 barn = listOf(
                     Barn(
                         navn = "Ole Dole",
-                        norskIdentifikator = "25058118020",
+                        norskIdentifikator = "01010010001",
                         aktørId = null
                     )
                 ),
@@ -59,19 +59,19 @@ class OmsorgspengerMidlertidigAleneSøknadTest {
               "versjon": "1.0.0",
               "mottattDato": "2020-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "02119970078"
+                "norskIdentitetsnummer": "01017000299"
               },
               "språk": "nb",
               "ytelse": {
                 "type": "OMP_UTV_MA",
                 "barn": [
                   {
-                    "norskIdentitetsnummer": "25058118020",
+                    "norskIdentitetsnummer": "01010010001",
                     "fødselsdato": null
                   }
                 ],
                 "annenForelder": {
-                  "norskIdentitetsnummer": "02119970078",
+                  "norskIdentitetsnummer": "01017000299",
                   "situasjon": "FENGSEL",
                   "situasjonBeskrivelse": "Sitter i fengsel..",
                   "periode": "2020-01-01/2020-10-01"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/kafka/OMPMidlertidigAleneSoknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/kafka/OMPMidlertidigAleneSoknadKonsumentTest.kt
@@ -106,7 +106,7 @@ class OMPMidlertidigAleneSoknadKonsumentTest : AbstractIntegrationTest() {
             {
               "aktørId": null,
               "navn": "Ole Dole",
-              "norskIdentifikator": "29076523302"
+              "norskIdentifikator": "01010010002"
             },
             {
               "aktørId": null,
@@ -120,7 +120,7 @@ class OMPMidlertidigAleneSoknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "2020-08-05",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "harForståttRettigheterOgPlikter": true,
           "dokumentId": [
@@ -134,7 +134,7 @@ class OMPMidlertidigAleneSoknadKonsumentTest : AbstractIntegrationTest() {
             "situasjonBeskrivelse": "Sitter i «fengsel..»",
             "periodeFraOgMed": "2020-01-01",
             "navn": "Berit",
-            "fnr": "02119970078",
+            "fnr": "01017000299",
             "periodeOver6Måneder": false,
             "situasjon": "FENGSEL"
           },
@@ -145,19 +145,19 @@ class OMPMidlertidigAleneSoknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "02119970078"
+              "norskIdentitetsnummer": "01017000299"
             },
             "ytelse": {
               "begrunnelse": null,
               "barn": [
                 {
                   "fødselsdato": null,
-                  "norskIdentitetsnummer": "29076523302"
+                  "norskIdentitetsnummer": "01010010002"
                 }
               ],
               "annenForelder": {
                 "situasjonBeskrivelse": "Sitter i «fengsel..»",
-                "norskIdentitetsnummer": "25058118020",
+                "norskIdentitetsnummer": "01010010001",
                 "periode": "2020-01-01\/2030-01-01",
                 "situasjon": "FENGSEL"
               },

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/utils/OMPMidlertidigAleneSoknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/utils/OMPMidlertidigAleneSoknadUtils.kt
@@ -24,7 +24,7 @@ internal object OMPMidlertidigAleneSoknadUtils {
         mottatt = mottatt,
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "02119970078",
+            fødselsnummer = "01017000299",
             fødselsdato = LocalDate.parse("2020-08-05"),
             etternavn = "Nordmann",
             mellomnavn = "Mellomnavn",
@@ -32,7 +32,7 @@ internal object OMPMidlertidigAleneSoknadUtils {
         ),
         annenForelder = AnnenForelder(
             navn = "Berit",
-            fnr = "02119970078",
+            fnr = "01017000299",
             situasjon = Situasjon.FENGSEL,
             situasjonBeskrivelse = "Sitter i «fengsel..»",
             periodeOver6Måneder = false,
@@ -42,7 +42,7 @@ internal object OMPMidlertidigAleneSoknadUtils {
         barn = listOf(
             Barn(
                 navn = "Ole Dole",
-                norskIdentifikator = "29076523302",
+                norskIdentifikator = "01010010002",
                 aktørId = null
             ),
             Barn(
@@ -60,13 +60,13 @@ internal object OMPMidlertidigAleneSoknadUtils {
         SøknadId(søknadId),
         Versjon("1.0.0"),
         mottatt,
-        no.nav.k9.søknad.felles.personopplysninger.Søker(NorskIdentitetsnummer.of("02119970078")),
+        no.nav.k9.søknad.felles.personopplysninger.Søker(NorskIdentitetsnummer.of("01017000299")),
         OmsorgspengerMidlertidigAlene(
             listOf(
-                no.nav.k9.søknad.felles.personopplysninger.Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("29076523302"))
+                no.nav.k9.søknad.felles.personopplysninger.Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("01010010002"))
             ),
             no.nav.k9.søknad.ytelse.omsorgspenger.utvidetrett.v1.AnnenForelder(
-                NorskIdentitetsnummer.of("25058118020"),
+                NorskIdentitetsnummer.of("01010010001"),
                 no.nav.k9.søknad.ytelse.omsorgspenger.utvidetrett.v1.AnnenForelder.SituasjonType.FENGSEL,
                 "Sitter i «fengsel..»",
                 Periode(LocalDate.parse("2020-01-01"), LocalDate.parse("2030-01-01"))

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/utils/SøknadUtils.kt
@@ -15,7 +15,7 @@ object SøknadUtils {
         språk = "nb",
         annenForelder = AnnenForelder(
             navn = "Berit",
-            fnr = "02119970078",
+            fnr = "01017000299",
             situasjon = Situasjon.FENGSEL,
             situasjonBeskrivelse = "Sitter i fengsel..",
             periodeOver6Måneder = false,
@@ -25,7 +25,7 @@ object SøknadUtils {
         barn = listOf(
             Barn(
                 navn = "Ole Dole",
-                norskIdentifikator = "25058118020",
+                norskIdentifikator = "01010010001",
                 aktørId = null
             )
         ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/api/domene/BarnTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/api/domene/BarnTest.kt
@@ -18,7 +18,7 @@ class BarnTest {
     @Test
     fun `Gyldig barn er gyldig`() {
         val gyldigBarn = Barn(
-            identitetsnummer = "02119970078",
+            identitetsnummer = "01017000299",
             fødselsdato = LocalDate.parse("2024-01-01"),
             aktørId = "12345",
             navn = "Barn Barnesen",
@@ -30,7 +30,7 @@ class BarnTest {
     @Test
     fun `Navnløse barn er ikke gyldig`() {
         val noname = Barn(
-            identitetsnummer = "02119970078",
+            identitetsnummer = "01017000299",
             fødselsdato = LocalDate.parse("2024-01-01"),
             aktørId = "12345",
             navn = "",
@@ -42,7 +42,7 @@ class BarnTest {
     @Test
     fun `Ufødte barn er ikke gyldig`() {
         val fremtidsbarn = Barn(
-            identitetsnummer = "02119970078",
+            identitetsnummer = "01017000299",
             fødselsdato = LocalDate.parse("2999-01-01"),
             aktørId = "12345",
             navn = "Barn Barnesen",
@@ -54,7 +54,7 @@ class BarnTest {
     @Test
     fun `Personer over 18 år er ikke gyldige barn`() {
         val voksen = Barn(
-            identitetsnummer = "02119970078",
+            identitetsnummer = "01017000299",
             fødselsdato = LocalDate.parse("1987-01-01"),
             aktørId = "12345",
             navn = "Indre Barnesen",
@@ -67,13 +67,13 @@ class BarnTest {
     fun `Det går an å kjøre valideringer på lister av barn`() {
         val flereBarn = listOf(
             Barn(
-                identitetsnummer = "02119970078",
+                identitetsnummer = "01017000299",
                 fødselsdato = LocalDate.parse("2999-01-01"),
                 aktørId = "12345",
                 navn = "Barn Barnesen",
                 type = TypeBarn.FRA_OPPSLAG
             ), Barn(
-                identitetsnummer = "02119970078",
+                identitetsnummer = "01017000299",
                 fødselsdato = LocalDate.parse("1987-01-01"),
                 aktørId = "12345",
                 navn = "Indre Barnesen",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/api/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/api/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
@@ -29,7 +29,7 @@ class OmsorgspengerUtbetalingArbeidstakerSøknadTest {
               "versjon": "1.1.0",
               "mottattDato": "2022-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "02119970078"
+                "norskIdentitetsnummer": "01017000299"
               },
               "ytelse": {
                 "type": "OMP_UT",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/kafka/OMPUtbetalingATSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/kafka/OMPUtbetalingATSøknadKonsumentTest.kt
@@ -116,7 +116,7 @@ class OMPUtbetalingATSøknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "1999-11-02",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "fosterbarn": [
             {
@@ -271,7 +271,7 @@ class OMPUtbetalingATSøknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "02119970078"
+              "norskIdentitetsnummer": "01017000299"
             },
             "ytelse": {
               "utenlandsopphold": {
@@ -288,7 +288,7 @@ class OMPUtbetalingATSøknadKonsumentTest : AbstractIntegrationTest() {
               "fosterbarn": [
                 {
                   "fødselsdato": null,
-                  "norskIdentitetsnummer": "26128027024"
+                  "norskIdentitetsnummer": "01010010007"
                 }
               ],
               "aktivitet": null,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/utils/OMPUtbetalingATSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/utils/OMPUtbetalingATSøknadUtils.kt
@@ -31,7 +31,7 @@ internal object OMPUtbetalingATSøknadUtils {
         mottatt = mottatt,
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "02119970078",
+            fødselsnummer = "01017000299",
             fødselsdato = LocalDate.parse("1999-11-02"),
             etternavn = "Nordmann",
             mellomnavn = null,
@@ -170,10 +170,10 @@ internal object OMPUtbetalingATSøknadUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("02119970078")),
+            K9Søker(NorskIdentitetsnummer.of("01017000299")),
             OmsorgspengerUtbetaling(
                 listOf(
-                    Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("26128027024"))
+                    Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("01010010007"))
                 ),
                 null,
                 listOf(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/api/domene/FosterbarnTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/api/domene/FosterbarnTest.kt
@@ -19,13 +19,13 @@ class FosterbarnTest {
             navn = "Barnesen",
             fødselsdato = LocalDate.parse("2022-01-01"),
             type = TypeBarn.FRA_OPPSLAG,
-            identitetsnummer = "26104500284"
+            identitetsnummer = "01010010000"
         ).somK9Barn()
         val forventetK9Barn =
             """
                 {
                     "fødselsdato" :null,
-                    "norskIdentitetsnummer":"26104500284"
+                    "norskIdentitetsnummer":"01010010000"
                 }
             """.trimIndent()
 
@@ -39,30 +39,30 @@ class FosterbarnTest {
                 navn = "Barnesen",
                 fødselsdato = LocalDate.parse("2022-01-01"),
                 type = TypeBarn.FOSTERBARN,
-                identitetsnummer = "26104500284"
+                identitetsnummer = "01010010000"
             ),
             Barn(
                 navn = "Barnesen v2",
                 fødselsdato = LocalDate.parse("2022-01-01"),
                 type = TypeBarn.FOSTERBARN,
-                identitetsnummer = "15121670744"
+                identitetsnummer = "01010010006"
             ),
             Barn(
                 navn = "Barnesen v2",
                 fødselsdato = LocalDate.parse("2022-01-01"),
                 type = TypeBarn.ANNET,
-                identitetsnummer = "18021839511"
+                identitetsnummer = "01010010008"
             )
         )
         val forventetK9Barn =
             """
                 [{
                     "fødselsdato" :null,
-                    "norskIdentitetsnummer":"26104500284"
+                    "norskIdentitetsnummer":"01010010000"
                 },
                 {
                     "fødselsdato" :null,
-                    "norskIdentitetsnummer":"15121670744"
+                    "norskIdentitetsnummer":"01010010006"
                 }]
             """.trimIndent()
 
@@ -77,7 +77,7 @@ class FosterbarnTest {
                 fødselsdato = LocalDate.parse("2022-01-01"),
                 type = TypeBarn.FRA_OPPSLAG,
                 aktørId = null,
-                identitetsnummer = "26104500284"
+                identitetsnummer = "01010010000"
             )
         )
     }
@@ -103,7 +103,7 @@ class FosterbarnTest {
                 fødselsdato = LocalDate.parse("2022-01-01"),
                 type = TypeBarn.FRA_OPPSLAG,
                 aktørId = null,
-                identitetsnummer = "26104500284"
+                identitetsnummer = "01010010000"
             ), 1, "Kan ikke være tomt eller blankt"
         )
     }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/api/domene/OmsorgspengerUtbetalingSnfSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/api/domene/OmsorgspengerUtbetalingSnfSøknadTest.kt
@@ -135,13 +135,13 @@ class OmsorgspengerUtbetalingSnfSøknadTest {
               "versjon": "1.1.0",
               "mottattDato": "2022-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "02119970078"
+                "norskIdentitetsnummer": "01017000299"
               },
               "ytelse": {
                 "type": "OMP_UT",
                 "fosterbarn": [
                   {
-                    "norskIdentitetsnummer": "26104500284",
+                    "norskIdentitetsnummer": "01010010000",
                     "fødselsdato": null
                   }
                 ],

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/kafka/OMPUtbetalingSNFSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/kafka/OMPUtbetalingSNFSøknadKonsumentTest.kt
@@ -109,7 +109,7 @@ class OMPUtbetalingSNFSøknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "2020-08-02",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "harDekketTiFørsteDagerSelv": true,
           "harSyktBarn": true,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/utils/OMPUtbetalingSNFSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/utils/OMPUtbetalingSNFSøknadUtils.kt
@@ -45,7 +45,7 @@ internal object OMPUtbetalingSNFSøknadUtils {
         mottatt = mottatt,
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "02119970078",
+            fødselsnummer = "01017000299",
             fødselsdato = LocalDate.parse("2020-08-02"),
             etternavn = "Nordmann",
             mellomnavn = "Mellomnavn",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/utils/SøknadUtils.kt
@@ -77,7 +77,7 @@ object SøknadUtils {
                 fødselsdato = LocalDate.parse("2022-01-01"),
                 type = TypeBarn.FOSTERBARN,
                 aktørId = null,
-                identitetsnummer = "26104500284"
+                identitetsnummer = "01010010000"
             )
         ),
         frilans = Frilans(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/BarnTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/BarnTest.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 class BarnTest {
     private companion object {
         val gyldigBarn = BarnDetaljer(
-            norskIdentifikator = "02119970078",
+            norskIdentifikator = "01017000299",
             fødselsdato = LocalDate.parse("2021-01-01"),
             aktørId = "10000001",
             navn = "Barnesen",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/K9FormatTest.kt
@@ -170,7 +170,7 @@ class K9FormatTest {
               },
               "barn" : {
                 "fødselsdato" : null,
-                "norskIdentitetsnummer" : "03028104560"
+                "norskIdentitetsnummer" : "01010010003"
               },
               "bosteder" : {
                 "perioder" : {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/OpplæringspengerSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/OpplæringspengerSøknadKonsumentTest.kt
@@ -498,7 +498,7 @@ class OpplæringspengerSøknadKonsumentTest : AbstractIntegrationTest() {
               "aktørId": "11111111111",
               "fødselsdato": null,
               "navn": "OLE DOLE",
-              "norskIdentifikator": "02119970078",
+              "norskIdentifikator": "01017000299",
               "årsakManglerIdentitetsnummer": null,
               "relasjonTilBarnet": "ANNET",
               "relasjonTilBarnetBeskrivelse": "Blaabla annet"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
@@ -29,7 +29,7 @@ object OlpPdfSøknadUtils {
                 fødselsdato = LocalDate.parse("1990-09-29"),
             ),
             barn = Barn(
-                norskIdentifikator = "02119970078",
+                norskIdentifikator = "01017000299",
                 navn = "OLE DOLE",
                 aktørId = "11111111111",
                 relasjonTilBarnet = BarnRelasjon.ANNET,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/SøknadUtils.kt
@@ -22,7 +22,7 @@ class SøknadUtils {
             aktørId = "12345",
             fødselsdato = LocalDate.parse("2000-01-01"),
             fornavn = "Kjell",
-            fødselsnummer = "25037139184"
+            fødselsnummer = "01010010005"
         )
 
         fun defaultSøknad(søknadId: String = UUID.randomUUID().toString()) = OpplæringspengerSøknad(
@@ -32,7 +32,7 @@ class SøknadUtils {
             mottatt = ZonedDateTime.of(2024, 1, 10, 3, 4, 5, 6, ZoneId.of("UTC")),
             språk = Språk.nb,
             barn = BarnDetaljer(  // check
-                norskIdentifikator = "03028104560",
+                norskIdentifikator = "01010010003",
                 fødselsdato = LocalDate.parse("2018-01-01"),
                 navn = "Barn Barnesen",
                 aktørId = null,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/api/domene/PilsSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/api/domene/PilsSøknadTest.kt
@@ -203,12 +203,12 @@ class PilsSøknadTest {
               "versjon": "1.0.0",
               "mottattDato": "2022-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "02119970078"
+                "norskIdentitetsnummer": "01017000299"
               },
               "ytelse": {
                 "type": "PLEIEPENGER_LIVETS_SLUTTFASE",
                 "pleietrengende": {
-                  "norskIdentitetsnummer": "06098523047",
+                  "norskIdentitetsnummer": "01010010004",
                   "fødselsdato": null
                 },
                 "søknadsperiode": [

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/api/domene/PleietrengendeTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/api/domene/PleietrengendeTest.kt
@@ -15,10 +15,10 @@ class PleietrengendeTest {
 
     @Test
     fun `Mapping til K9Pleietrengende blir som forventet`() {
-        Pleietrengende(navn = "Ole", norskIdentitetsnummer = "06098523047")
+        Pleietrengende(navn = "Ole", norskIdentitetsnummer = "01010010004")
             .somK9Pleietrengende().also {
                 JSONAssert.assertEquals(
-                    """{"norskIdentitetsnummer":"06098523047","fødselsdato":null}""",
+                    """{"norskIdentitetsnummer":"01010010004","fødselsdato":null}""",
                     JsonUtils.toString(it),
                     true
                 )
@@ -36,13 +36,13 @@ class PleietrengendeTest {
 
     @Test
     fun `Gyldig pleietrengende gir ingen valideringsfeil`() {
-        Validator.verifiserIngenValideringsFeil(Pleietrengende(navn = "Ole", norskIdentitetsnummer = "06098523047"))
+        Validator.verifiserIngenValideringsFeil(Pleietrengende(navn = "Ole", norskIdentitetsnummer = "01010010004"))
     }
 
     @Test
     fun `Blankt navn skal gi valideringsfeil`() {
         Validator.verifiserValideringsFeil(
-            Pleietrengende(navn = " ", norskIdentitetsnummer = "06098523047"),
+            Pleietrengende(navn = " ", norskIdentitetsnummer = "01010010004"),
             1,
             "Kan ikke være tomt eller blankt"
         )

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/kafka/PleiepengerILivetsSluttfaseSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/kafka/PleiepengerILivetsSluttfaseSøknadKonsumentTest.kt
@@ -117,13 +117,13 @@ class PleiepengerILivetsSluttfaseSøknadKonsumentTest : AbstractIntegrationTest(
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "pleietrengende": {
             "fødselsdato": null,
             "navn": "Bjarne",
             "årsakManglerIdentitetsnummer": null,
-            "norskIdentitetsnummer": "02119970078"
+            "norskIdentitetsnummer": "01017000299"
           },
           "flereSokere": "JA",
           "selvstendigNæringsdrivende": {
@@ -316,7 +316,7 @@ class PleiepengerILivetsSluttfaseSøknadKonsumentTest : AbstractIntegrationTest(
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "02119970078"
+              "norskIdentitetsnummer": "01017000299"
             },
             "ytelse": {
               "arbeidstid": {
@@ -352,7 +352,7 @@ class PleiepengerILivetsSluttfaseSøknadKonsumentTest : AbstractIntegrationTest(
               },
               "pleietrengende": {
                 "fødselsdato": null,
-                "norskIdentitetsnummer": "02119970078"
+                "norskIdentitetsnummer": "01017000299"
               },
               "opptjeningAktivitet": {
                 "frilanser": {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/utils/PilsSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/utils/PilsSøknadUtils.kt
@@ -48,7 +48,7 @@ import no.nav.k9.søknad.ytelse.pls.v1.Pleietrengende as K9Pleietrengende
 object PilsSøknadUtils {
 
     fun gyldigSøknad(
-        søkerFødselsnummer: String = "02119970078",
+        søkerFødselsnummer: String = "01017000299",
         søknadId: String = UUID.randomUUID().toString(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC"))
     ) = PilsSøknadMottatt(
@@ -95,7 +95,7 @@ object PilsSøknadUtils {
         ),
         vedleggId = listOf("123", "456"),
         opplastetIdVedleggId = listOf("987"),
-        pleietrengende = Pleietrengende(norskIdentitetsnummer = "02119970078", navn = "Bjarne"),
+        pleietrengende = Pleietrengende(norskIdentitetsnummer = "01017000299", navn = "Bjarne"),
         medlemskap = Medlemskap(
             harBoddIUtlandetSiste12Mnd = true,
             utenlandsoppholdSiste12Mnd = listOf(
@@ -239,9 +239,9 @@ object PilsSøknadUtils {
         SøknadId(søknadId),
         Versjon("1.0.0"),
         mottatt,
-        K9Søker(NorskIdentitetsnummer.of("02119970078")),
+        K9Søker(NorskIdentitetsnummer.of("01017000299")),
         PleipengerLivetsSluttfase()
-            .medPleietrengende(K9Pleietrengende().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("02119970078")))
+            .medPleietrengende(K9Pleietrengende().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("01017000299")))
             .medUtenlandsopphold(
                 K9Utenlandsopphold()
                     .medPerioder(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/utils/SøknadUtils.kt
@@ -32,7 +32,7 @@ object SøknadUtils {
         språk = "nb",
         vedleggUrls = listOf(URI.create("http://localhost:8080/vedlegg/1").toURL()),
         opplastetIdVedleggUrls = listOf(URI.create("http://localhost:8080/vedlegg/2").toURL()),
-        pleietrengende = Pleietrengende(norskIdentitetsnummer = "06098523047", navn = "Bjarne"),
+        pleietrengende = Pleietrengende(norskIdentitetsnummer = "01010010004", navn = "Bjarne"),
         fraOgMed = LocalDate.parse("2021-01-01"),
         tilOgMed = LocalDate.parse("2021-01-10"),
         skalJobbeOgPleieSammeDag = true,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/api/EndringsmeldingControllerTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/api/EndringsmeldingControllerTest.kt
@@ -63,7 +63,7 @@ class EndringsmeldingControllerTest {
     private lateinit var metrikkService: MetrikkService
 
     private companion object {
-        private val søkerMedBarn = "02119970078"
+        private val søkerMedBarn = "01017000299"
         private val barnIdentitetsnummer = "18909798651"
     }
 

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/kafka/PleiepengerSyktBarnEndringsmeldingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/kafka/PleiepengerSyktBarnEndringsmeldingKonsumentTest.kt
@@ -91,7 +91,7 @@ class PleiepengerSyktBarnEndringsmeldingKonsumentTest : AbstractIntegrationTest(
          {
             "søker": {
                "aktørId": "123456",
-               "fødselsnummer": "02119970078",
+               "fødselsnummer": "01017000299",
                "fødselsdato": "1999-11-02",
                "fornavn": "Ola",
                "mellomnavn": "Mellomnavn",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/utils/EndringsmeldingUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/utils/EndringsmeldingUtils.kt
@@ -13,7 +13,7 @@ internal object EndringsmeldingUtils {
     internal fun defaultEndringsmelding(søknadsId: String, mottatt: ZonedDateTime) = PSBEndringsmeldingMottatt(
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "02119970078",
+            fødselsnummer = "01017000299",
             etternavn = "Nordmann",
             mellomnavn = "Mellomnavn",
             fornavn = "Ola",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/BarnValidationTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/BarnValidationTest.kt
@@ -10,7 +10,7 @@ class BarnValidationTest {
     private companion object {
         val felt = "barn"
         val gyldigBarn = BarnDetaljer(
-            fødselsnummer = "02119970078",
+            fødselsnummer = "01017000299",
             fødselsdato = LocalDate.parse("2021-01-01"),
             aktørId = "10000001",
             navn = "Barnesen",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SerDesTest.kt
@@ -66,7 +66,7 @@ internal class SerDesTest {
               "språk": "nb",
               "søkerNorskIdent": null,
               "barn": {
-                "fødselsnummer": "03028104560",
+                "fødselsnummer": "01010010003",
                 "navn": "Barn Barnesen",
                 "fødselsdato": "2018-01-01",
                 "aktørId": null,
@@ -317,14 +317,14 @@ internal class SerDesTest {
           "søknadId": "$søknadsId",
           "søker": {
             "aktørId": "12345",
-            "fødselsnummer": "26104500284",
+            "fødselsnummer": "01010010000",
             "fødselsdato": "1945-10-26",
             "etternavn": "Nordmann",
             "fornavn": "Ola",
             "mellomnavn": null
           },
           "barn": {
-            "fødselsnummer": "03028104560",
+            "fødselsnummer": "01010010003",
             "navn": "Barn Barnesen",
             "aktørId": "12345",
             "fødselsdato": "2018-01-01",
@@ -566,13 +566,13 @@ internal class SerDesTest {
             søknadId = søknadId,
             barn = BarnDetaljer(
                 aktørId = "12345",
-                fødselsnummer = "03028104560",
+                fødselsnummer = "01010010003",
                 fødselsdato = LocalDate.parse("2018-01-01"),
                 navn = "Barn Barnesen"
             ),
             søker = Søker(
                 aktørId = "12345",
-                fødselsnummer = "26104500284",
+                fødselsnummer = "01010010000",
                 fødselsdato = LocalDate.parse("1945-10-26"),
                 etternavn = "Nordmann",
                 fornavn = "Ola"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SoknadValidationTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SoknadValidationTest.kt
@@ -84,7 +84,7 @@ class SoknadValidationTest {
         språk = Språk.nb,
         barn = BarnDetaljer(
             aktørId = null,
-            fødselsnummer = "02119970078",
+            fødselsnummer = "01017000299",
             fødselsdato = LocalDate.now(),
             navn = "Barn"
         ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/k9Format/K9FormatTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/k9Format/K9FormatTest.kt
@@ -75,7 +75,7 @@ class K9FormatTest {
               "ytelse": {
                 "type": "PLEIEPENGER_SYKT_BARN",
                 "barn": {
-                  "norskIdentitetsnummer": "03028104560",
+                  "norskIdentitetsnummer": "01010010003",
                   "fødselsdato": null
                 },
                 "erSammenMedBarnet": null,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/PleiepengerSyktBarnSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/PleiepengerSyktBarnSøknadKonsumentTest.kt
@@ -89,14 +89,14 @@ class PleiepengerSyktBarnSøknadKonsumentTest : AbstractIntegrationTest() {
              "aktørId": "123456",
              "etternavn": "Nordmann",
              "fornavn": "Ola",
-             "fødselsnummer": "02119970078",
+             "fødselsnummer": "01017000299",
              "fødselsdato": "1999-11-02",
              "mellomnavn": "Mellomnavn"
            },
            "barn": {
              "aktørId": "11111111111",
              "fødselsdato": null,
-             "fødselsnummer": "02119970078",
+             "fødselsnummer": "01017000299",
              "navn": "Ole Dole",
              "årsakManglerIdentitetsnummer": null
            },

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfGeneratorTest.kt
@@ -89,7 +89,7 @@ class PSBSøknadPdfGeneratorTest {
                     fødselsdato = LocalDate.parse("1990-09-29"),
                 ),
                 barn = Barn(
-                    fødselsnummer = "02119970078",
+                    fødselsnummer = "01017000299",
                     navn = "OLE DOLE",
                     aktørId = "11111111111"
                 ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/utils/PSBSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/utils/PSBSøknadUtils.kt
@@ -47,7 +47,7 @@ internal object PSBSøknadUtils {
         tilOgMed = LocalDate.parse("2021-01-01"),
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "02119970078",
+            fødselsnummer = "01017000299",
             etternavn = "Nordmann",
             mellomnavn = "Mellomnavn",
             fornavn = "Ola",
@@ -55,7 +55,7 @@ internal object PSBSøknadUtils {
         ),
         barn = Barn(
             navn = "Ole Dole",
-            fødselsnummer = "02119970078",
+            fødselsnummer = "01017000299",
             aktørId = "11111111111"
         ),
         vedleggId = listOf("123", "456"),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/utils/SøknadUtils.kt
@@ -67,7 +67,7 @@ class SøknadUtils {
             aktørId = "12345",
             fødselsdato = LocalDate.parse("2000-01-01"),
             fornavn = "Kjell",
-            fødselsnummer = "25037139184"
+            fødselsnummer = "01010010005"
         )
 
         fun defaultSøknad(søknadId: String = UUID.randomUUID().toString()) = PleiepengerSyktBarnSøknad(
@@ -77,7 +77,7 @@ class SøknadUtils {
             mottatt = ZonedDateTime.of(2021, 1, 10, 3, 4, 5, 6, ZoneId.of("UTC")),
             språk = Språk.nb,
             barn = BarnDetaljer(
-                fødselsnummer = "03028104560",
+                fødselsnummer = "01010010003",
                 fødselsdato = LocalDate.parse("2018-01-01"),
                 navn = "Barn Barnesen",
                 aktørId = null

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseInntektRapporteringKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseInntektRapporteringKonsumentTest.kt
@@ -154,7 +154,7 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "oppgittInntektForPeriode": {
                 "arbeidstakerOgFrilansInntekt": 6000,
@@ -175,7 +175,7 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "02119970078"
+              "norskIdentitetsnummer": "01017000299"
             },
             "ytelse": {
               "type": "UNGDOMSYTELSE",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
@@ -167,7 +167,7 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "språk": "nb",
           "dokumentId": [
@@ -182,7 +182,7 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
             "språk": "nb",
             "mottattDato": "$mottatt",
             "søker": {
-              "norskIdentitetsnummer": "02119970078"
+              "norskIdentitetsnummer": "01017000299"
             },
             "bekreftelse": {
               "type": "UNG_ENDRET_STARTDATO",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadKonsumentTest.kt
@@ -149,7 +149,7 @@ class UngdomsytelsesøknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "02119970078"
+            "fødselsnummer": "01017000299"
           },
           "startdato": "2022-01-01",
           "barn": [
@@ -178,7 +178,7 @@ class UngdomsytelsesøknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "02119970078"
+              "norskIdentitetsnummer": "01017000299"
             },
             "ytelse": {
               "type": "UNGDOMSYTELSE",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
@@ -29,7 +29,7 @@ object InntektrapporteringUtils {
     )
 
     fun gyldigInntektsrapportering(
-        søkerFødselsnummer: String = "02119970078",
+        søkerFødselsnummer: String = "01017000299",
         søknadId: String = UUID.randomUUID().toString(),
         deltakelseId: UUID = UUID.randomUUID(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
@@ -73,7 +73,7 @@ object InntektrapporteringUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("02119970078")),
+            K9Søker(NorskIdentitetsnummer.of("01017000299")),
             ytelse
 
         ).medKildesystem(Kildesystem.SØKNADSDIALOG)

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelseOppgavebekreftelseUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelseOppgavebekreftelseUtils.kt
@@ -18,7 +18,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 object UngdomsytelseOppgavebekreftelseUtils {
 
     fun oppgavebekreftelseMottatt(
-        søkerFødselsnummer: String = "02119970078",
+        søkerFødselsnummer: String = "01017000299",
         oppgaveReferanse: String = UUID.randomUUID().toString(),
         oppgave: KomplettUngdomsytelseOppgaveDTO = KomplettEndretStartdatoUngdomsytelseOppgaveDTO(
             oppgaveReferanse = oppgaveReferanse,
@@ -55,7 +55,7 @@ object UngdomsytelseOppgavebekreftelseUtils {
             .medSøknadId(søknadId)
             .medVersjon("1.0.0")
             .medMottattDato(mottatt)
-            .medSøker(K9Søker(NorskIdentitetsnummer.of("02119970078")))
+            .medSøker(K9Søker(NorskIdentitetsnummer.of("01017000299")))
             .medBekreftelse(bekreftelse)
             .medKildesystem(Kildesystem.SØKNADSDIALOG)
     }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
@@ -21,7 +21,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 object UngdomsytelsesøknadUtils {
 
     fun gyldigSøknad(
-        søkerFødselsnummer: String = "02119970078",
+        søkerFødselsnummer: String = "01017000299",
         søknadId: String = UUID.randomUUID().toString(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
         deltakelseId: UUID = UUID.randomUUID(),
@@ -73,7 +73,7 @@ object UngdomsytelsesøknadUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("02119970078")),
+            K9Søker(NorskIdentitetsnummer.of("01017000299")),
             ytelse
 
         ).medKildesystem(Kildesystem.SØKNADSDIALOG)


### PR DESCRIPTION
## Erstatter ikke-godkjente fødselsnummer

Bytter ut fødselsnummer som ikke er på [godkjent liste](https://github.com/navikt/sif-gha-workflows/tree/main/.github/actions/sif-code-scan/allowed-fnr) med fiktive fødselsnummer fra sif-gha-workflows allowed-fnr.

Dette sikrer at `sif-code-scan` ikke feiler i CI/CD-pipeline.