### PR TITLE
Erstatt fiktive fødselsnummer med syntetisk fnr

### DIFF
--- a/src/test/kotlin/no/nav/brukerdialog/AbstractIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/AbstractIntegrationTest.kt
@@ -161,7 +161,7 @@ abstract class AbstractIntegrationTest {
         )
     }
 
-    protected fun mockSøker(aktørId: String = "1234", fnr: String = "01017000299"): Søker {
+    protected fun mockSøker(aktørId: String = "1234", fnr: String = "23500180528"): Søker {
         val søker = Søker(
             aktørId = aktørId,
             fødselsdato = LocalDate.parse("1999-11-02"),

--- a/src/test/kotlin/no/nav/brukerdialog/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/utils/SøknadUtils.kt
@@ -21,7 +21,7 @@ class SøknadUtils {
             fødselsdato = LocalDate.parse("1999-11-02"),
             fornavn = "MOR",
             etternavn = "MORSEN",
-            fødselsnummer = "01017000299"
+            fødselsnummer = "23500180528"
         )
 
         val metadata = MetaInfo(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengerInntektRapporteringKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengerInntektRapporteringKonsumentTest.kt
@@ -153,7 +153,7 @@ class AktivitetspengerInntektRapporteringKonsumentTest : AbstractIntegrationTest
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "oppgittInntektForPeriode": {
                 "arbeidstakerOgFrilansInntekt": 6000,
@@ -174,7 +174,7 @@ class AktivitetspengerInntektRapporteringKonsumentTest : AbstractIntegrationTest
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "01017000299"
+              "norskIdentitetsnummer": "23500180528"
             },
             "ytelse": {
               "type": "AKTIVITETSPENGER",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengersøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengersøknadKonsumentTest.kt
@@ -132,7 +132,7 @@ class AktivitetspengersøknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "startdato": "2022-01-01",
           "barn": [
@@ -161,7 +161,7 @@ class AktivitetspengersøknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "01017000299"
+              "norskIdentitetsnummer": "23500180528"
             },
             "ytelse": {
               "type": "AKTIVITETSPENGER",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengerOppgavebekreftelseUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengerOppgavebekreftelseUtils.kt
@@ -47,7 +47,7 @@ object AktivitetspengerOppgavebekreftelseUtils {
     )
 
     fun oppgavebekreftelseMottatt(
-        søkerFødselsnummer: String = "01017000299",
+        søkerFødselsnummer: String = "23500180528",
         oppgaveReferanse: String = UUID.randomUUID().toString(),
         oppgave: KomplettAktivitetspengerOppgaveDTO = defaultKomplettOppgave.copy(
             oppgaveReferanse = oppgaveReferanse
@@ -79,7 +79,7 @@ object AktivitetspengerOppgavebekreftelseUtils {
             .medSøknadId(søknadId)
             .medVersjon("1.0.0")
             .medMottattDato(mottatt)
-            .medSøker(K9Søker(NorskIdentitetsnummer.of("01017000299")))
+            .medSøker(K9Søker(NorskIdentitetsnummer.of("23500180528")))
             .medBekreftelse(bekreftelse)
             .medKildesystem(Kildesystem.SØKNADSDIALOG)
     }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengersøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengersøknadUtils.kt
@@ -20,7 +20,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 object AktivitetspengersøknadUtils {
 
     fun gyldigSøknad(
-        søkerFødselsnummer: String = "01017000299",
+        søkerFødselsnummer: String = "23500180528",
         søknadId: String = UUID.randomUUID().toString(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
     ): AktivitetspengersøknadMottatt {
@@ -81,7 +81,7 @@ object AktivitetspengersøknadUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("01017000299")),
+            K9Søker(NorskIdentitetsnummer.of("23500180528")),
             ytelse
         ).medKildesystem(Kildesystem.SØKNADSDIALOG)
         return søknad

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/InntektrapporteringUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/InntektrapporteringUtils.kt
@@ -28,7 +28,7 @@ object InntektrapporteringUtils {
     )
 
     fun gyldigInntektsrapportering(
-        søkerFødselsnummer: String = "01017000299",
+        søkerFødselsnummer: String = "23500180528",
         søknadId: String = UUID.randomUUID().toString(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
         oppgittInntektForPeriode: OppgittInntektForPeriode = OppgittInntektForPeriode(
@@ -69,7 +69,7 @@ object InntektrapporteringUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("01017000299")),
+            K9Søker(NorskIdentitetsnummer.of("23500180528")),
             ytelse
 
         ).medKildesystem(Kildesystem.SØKNADSDIALOG)

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/EttersendingSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/api/domene/EttersendingSøknadTest.kt
@@ -22,11 +22,11 @@ class EttersendingSøknadTest {
               "versjon": "0.0.1",
               "mottattDato": "2020-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "01017000299"
+                "norskIdentitetsnummer": "23500180528"
               },
               "type": "LEGEERKLÆRING",
               "pleietrengende": {
-                "norskIdentitetsnummer": "01017000299"
+                "norskIdentitetsnummer": "23500180528"
               },
               "ytelse": "PLEIEPENGER_LIVETS_SLUTTFASE"
             }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/utils/EttersendelseUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ettersendelse/utils/EttersendelseUtils.kt
@@ -23,7 +23,7 @@ internal object EttersendingUtils {
         søknadstype = no.nav.brukerdialog.ytelse.ettersendelse.api.domene.Søknadstype.PLEIEPENGER_LIVETS_SLUTTFASE,
         beskrivelse = "Pleiepenger .....",
         ettersendelsesType = EttersendelseType.LEGEERKLÆRING,
-        pleietrengende = no.nav.brukerdialog.ytelse.ettersendelse.api.domene.Pleietrengende(norskIdentitetsnummer = "01017000299"),
+        pleietrengende = no.nav.brukerdialog.ytelse.ettersendelse.api.domene.Pleietrengende(norskIdentitetsnummer = "23500180528"),
         harBekreftetOpplysninger = true,
         harForståttRettigheterOgPlikter = true
     )

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/felles/BarnTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/felles/BarnTest.kt
@@ -18,7 +18,7 @@ class BarnTest {
     @Test
     fun `Barn equals test`() {
         val barn = Barn(
-            norskIdentifikator = "01017000299",
+            norskIdentifikator = "23500180528",
             fødselsdato = LocalDate.parse("2022-01-01"),
             aktørId = "12345",
             navn = "Barn Barnesen"
@@ -26,7 +26,7 @@ class BarnTest {
         assertFalse(barn.equals(null))
         assertTrue(
             barn == Barn(
-                norskIdentifikator = "01017000299",
+                norskIdentifikator = "23500180528",
                 fødselsdato = LocalDate.parse("2022-01-01"),
                 aktørId = "12345",
                 navn = "Barn Barnesen"
@@ -43,7 +43,7 @@ class BarnTest {
                 mellomnavn = null,
                 etternavn = "Barnesen",
                 aktørId = "123",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
         val barn = Barn(navn = "Barn uten identifikator", aktørId = "123")
@@ -55,7 +55,7 @@ class BarnTest {
     @Test
     fun `Barn til k9Barn blir som forventet`() {
         val barn = Barn(
-            norskIdentifikator = "01017000299",
+            norskIdentifikator = "23500180528",
             fødselsdato = LocalDate.parse("2022-01-01"),
             aktørId = "12345",
             navn = "Barn Barnesen"
@@ -64,7 +64,7 @@ class BarnTest {
         val forventetK9Barn = JSONObject(
             """
             {
-              "norskIdentitetsnummer": "01017000299",
+              "norskIdentitetsnummer": "23500180528",
               "fødselsdato": null
             }
         """.trimIndent()
@@ -76,7 +76,7 @@ class BarnTest {
     @Test
     fun `Gyldig barn gir ingen valideringsfeil`() {
         Barn(
-            norskIdentifikator = "01017000299",
+            norskIdentifikator = "23500180528",
             navn = "Barnesen"
         ).valider("barn").verifiserIngenValideringsFeil()
     }
@@ -108,7 +108,7 @@ class BarnTest {
     @Test
     fun `Forvent valideringsfeil dersom navn er blank`() {
         Barn(
-            norskIdentifikator = "01017000299",
+            norskIdentifikator = "23500180528",
             navn = " "
         ).valider("barn").verifiserValideringsFeil(1, listOf("barn.navn kan ikke være tomt eller blank."))
     }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneomsorgBarnTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneomsorgBarnTest.kt
@@ -22,7 +22,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 mellomnavn = null,
                 etternavn = "Barnesen",
                 aktørId = "123",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
         val barn = Barn(
@@ -43,12 +43,12 @@ class OmsorgsdagerAleneomsorgBarnTest {
             navn = "Barn uten identifikator",
             type = TypeBarn.FRA_OPPSLAG,
             aktørId = "123",
-            identitetsnummer = "01017000299",
+            identitetsnummer = "23500180528",
             tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
         )
         val forventetK9Barn = """
             {
-              "norskIdentitetsnummer": "01017000299",
+              "norskIdentitetsnummer": "23500180528",
               "fødselsdato": null
             }
         """.trimIndent()
@@ -63,7 +63,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 navn = "Barn uten identifikator",
                 type = TypeBarn.FOSTERBARN,
                 fødselsdato = LocalDate.now().minusMonths(4),
-                identitetsnummer = "01017000299",
+                identitetsnummer = "23500180528",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
             )
         )
@@ -92,7 +92,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 navn = " ",
                 type = TypeBarn.FRA_OPPSLAG,
                 aktørId = "123",
-                identitetsnummer = "01017000299",
+                identitetsnummer = "23500180528",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
             ), 1, "Kan ikke være tomt eller blankt"
         )
@@ -105,7 +105,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 navn = "barnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnbarnb",
                 type = TypeBarn.FRA_OPPSLAG,
                 aktørId = "123",
-                identitetsnummer = "01017000299",
+                identitetsnummer = "23500180528",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
             ), 1, "Kan ikke være mer enn 100 tegn"
         )
@@ -119,7 +119,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 type = TypeBarn.FOSTERBARN,
                 fødselsdato = null,
                 aktørId = "123",
-                identitetsnummer = "01017000299",
+                identitetsnummer = "23500180528",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
             ), 1, "Må være satt når 'type' er annet enn 'FRA_OPPSLAG'"
         )
@@ -132,7 +132,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
                 navn = "Barnesen",
                 type = TypeBarn.FRA_OPPSLAG,
                 aktørId = "123",
-                identitetsnummer = "01017000299",
+                identitetsnummer = "23500180528",
                 tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
                 dato = null
             ), 1, "Må være satt når 'tidspunktForAleneomsorg' er 'SISTE_2_ÅRENE'"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneomsorgSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/api/domene/OmsorgsdagerAleneomsorgSøknadTest.kt
@@ -55,7 +55,7 @@ class OmsorgsdagerAleneomsorgSøknadTest {
                 mellomnavn = null,
                 etternavn = "Barnesen",
                 aktørId = "1234",
-                identitetsnummer = "01017000299"
+                identitetsnummer = "23500180528"
             )
         )
         søknad.leggTilIdentifikatorPåBarnHvisMangler(barnFraOppslag)
@@ -122,7 +122,7 @@ class OmsorgsdagerAleneomsorgSøknadTest {
                   "versjon": "1.0.0",
                   "mottattDato": "2020-01-02T03:04:05Z",
                   "søker": {
-                    "norskIdentitetsnummer": "01017000299"
+                    "norskIdentitetsnummer": "23500180528"
                   },
                   "ytelse": {
                     "type": "OMP_UTV_AO",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/kafka/OMPAleneomsorgSoknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/kafka/OMPAleneomsorgSoknadKonsumentTest.kt
@@ -139,7 +139,7 @@ class OMPAleneomsorgSoknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "1993-01-04",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "harForståttRettigheterOgPlikter": true,
           "dokumentId": [
@@ -155,7 +155,7 @@ class OMPAleneomsorgSoknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "01017000299"
+              "norskIdentitetsnummer": "23500180528"
             },
             "ytelse": {
               "barn": {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/utils/OMPAleneomsorgSoknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengeraleneomsorg/utils/OMPAleneomsorgSoknadUtils.kt
@@ -17,7 +17,7 @@ import java.time.ZonedDateTime
 internal object OMPAleneomsorgSoknadUtils {
 
     internal fun defaultSøknad(søknadId: String, mottatt: ZonedDateTime): OMPAleneomsorgSoknadMottatt {
-        val søkerFødselsnummer = "01017000299"
+        val søkerFødselsnummer = "23500180528"
         return OMPAleneomsorgSoknadMottatt(
             språk = "nb",
             søknadId = søknadId,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerUtvidetRettSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/api/domene/OmsorgspengerUtvidetRettSøknadTest.kt
@@ -19,7 +19,7 @@ class OmsorgspengerUtvidetRettSøknadTest {
             språk = "nb",
             kroniskEllerFunksjonshemming = true,
             barn = Barn(
-                norskIdentifikator = "01017000299",
+                norskIdentifikator = "23500180528",
                 navn = "Barn Barnesen"
             ),
             relasjonTilBarnet = SøkerBarnRelasjon.FAR,
@@ -71,12 +71,12 @@ class OmsorgspengerUtvidetRettSøknadTest {
                   "mottattDato": "2020-01-02T03:04:05Z",
                   "søknadId": "${søknad.søknadId}",
                   "søker": {
-                    "norskIdentitetsnummer": "01017000299"
+                    "norskIdentitetsnummer": "23500180528"
                   },
                   "ytelse": {
                     "barn": {
                       "fødselsdato": null,
-                      "norskIdentitetsnummer": "01017000299"
+                      "norskIdentitetsnummer": "23500180528"
                     },
                     "kroniskEllerFunksjonshemming": true,
                     "type": "OMP_UTV_KS",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/kafka/OmsorgspengerKroniskSyktBarnSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/kafka/OmsorgspengerKroniskSyktBarnSøknadKonsumentTest.kt
@@ -113,7 +113,7 @@ class OmsorgspengerKroniskSyktBarnSøknadKonsumentTest : AbstractIntegrationTest
             "aktørId": "123456",
             "fødselsdato": "2020-01-01",
             "navn": "Ole Dole Doffen",
-            "norskIdentifikator": "01017000299"
+            "norskIdentifikator": "23500180528"
           },
           "kroniskEllerFunksjonshemming": false,
           "søker": {
@@ -153,7 +153,7 @@ class OmsorgspengerKroniskSyktBarnSøknadKonsumentTest : AbstractIntegrationTest
             "ytelse": {
               "barn": {
                 "fødselsdato": null,
-                "norskIdentitetsnummer": "01017000299"
+                "norskIdentitetsnummer": "23500180528"
               },
               "kroniskEllerFunksjonshemming": true,
               "høyereRisikoForFravær": true,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/pdf/OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest.kt
@@ -47,7 +47,7 @@ class OMPUTVKroniskSyktBarnSøknadPdfGeneratorTest {
                 fødselsdato = LocalDate.now().minusYears(20)
             ),
             barn = Barn(
-                norskIdentifikator = "01017000299",
+                norskIdentifikator = "23500180528",
                 fødselsdato = LocalDate.now(),
                 aktørId = "123456",
                 navn = "Ole Dole"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/OMPKSSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/OMPKSSøknadUtils.kt
@@ -25,7 +25,7 @@ object OMPKSSøknadUtils {
     )
 
     val barn = Barn(
-        norskIdentifikator = "01017000299",
+        norskIdentifikator = "23500180528",
         navn = "Ole Dole Doffen",
         aktørId = "123456",
         fødselsdato = LocalDate.parse("2020-01-01")
@@ -39,7 +39,7 @@ object OMPKSSøknadUtils {
         ),
         OmsorgspengerKroniskSyktBarn(
             no.nav.k9.søknad.felles.personopplysninger.Barn()
-                .medNorskIdentitetsnummer(NorskIdentitetsnummer.of("01017000299")),
+                .medNorskIdentitetsnummer(NorskIdentitetsnummer.of("23500180528")),
             true,
             true,
             "Beskrivelse av høyere risiko for fravær"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerkronisksyktbarn/utils/SøknadUtils.kt
@@ -12,7 +12,7 @@ internal object SøknadUtils {
         språk = "nb",
         mottatt = ZonedDateTime.parse("2020-01-02T03:04:05.000Z", JacksonConfiguration.zonedDateTimeFormatter),
         barn = Barn(
-            norskIdentifikator = "01017000299",
+            norskIdentifikator = "23500180528",
             fødselsdato = null,
             aktørId = null,
             navn = "Barn Barnsen"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMidlertidigAleneSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/api/domene/OmsorgspengerMidlertidigAleneSøknadTest.kt
@@ -59,7 +59,7 @@ class OmsorgspengerMidlertidigAleneSøknadTest {
               "versjon": "1.0.0",
               "mottattDato": "2020-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "01017000299"
+                "norskIdentitetsnummer": "23500180528"
               },
               "språk": "nb",
               "ytelse": {
@@ -71,7 +71,7 @@ class OmsorgspengerMidlertidigAleneSøknadTest {
                   }
                 ],
                 "annenForelder": {
-                  "norskIdentitetsnummer": "01017000299",
+                  "norskIdentitetsnummer": "23500180528",
                   "situasjon": "FENGSEL",
                   "situasjonBeskrivelse": "Sitter i fengsel..",
                   "periode": "2020-01-01/2020-10-01"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/kafka/OMPMidlertidigAleneSoknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/kafka/OMPMidlertidigAleneSoknadKonsumentTest.kt
@@ -120,7 +120,7 @@ class OMPMidlertidigAleneSoknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "2020-08-05",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "harForståttRettigheterOgPlikter": true,
           "dokumentId": [
@@ -134,7 +134,7 @@ class OMPMidlertidigAleneSoknadKonsumentTest : AbstractIntegrationTest() {
             "situasjonBeskrivelse": "Sitter i «fengsel..»",
             "periodeFraOgMed": "2020-01-01",
             "navn": "Berit",
-            "fnr": "01017000299",
+            "fnr": "23500180528",
             "periodeOver6Måneder": false,
             "situasjon": "FENGSEL"
           },
@@ -145,7 +145,7 @@ class OMPMidlertidigAleneSoknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "01017000299"
+              "norskIdentitetsnummer": "23500180528"
             },
             "ytelse": {
               "begrunnelse": null,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/utils/OMPMidlertidigAleneSoknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/utils/OMPMidlertidigAleneSoknadUtils.kt
@@ -24,7 +24,7 @@ internal object OMPMidlertidigAleneSoknadUtils {
         mottatt = mottatt,
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "01017000299",
+            fødselsnummer = "23500180528",
             fødselsdato = LocalDate.parse("2020-08-05"),
             etternavn = "Nordmann",
             mellomnavn = "Mellomnavn",
@@ -32,7 +32,7 @@ internal object OMPMidlertidigAleneSoknadUtils {
         ),
         annenForelder = AnnenForelder(
             navn = "Berit",
-            fnr = "01017000299",
+            fnr = "23500180528",
             situasjon = Situasjon.FENGSEL,
             situasjonBeskrivelse = "Sitter i «fengsel..»",
             periodeOver6Måneder = false,
@@ -60,7 +60,7 @@ internal object OMPMidlertidigAleneSoknadUtils {
         SøknadId(søknadId),
         Versjon("1.0.0"),
         mottatt,
-        no.nav.k9.søknad.felles.personopplysninger.Søker(NorskIdentitetsnummer.of("01017000299")),
+        no.nav.k9.søknad.felles.personopplysninger.Søker(NorskIdentitetsnummer.of("23500180528")),
         OmsorgspengerMidlertidigAlene(
             listOf(
                 no.nav.k9.søknad.felles.personopplysninger.Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("01010010002"))

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/utils/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengermidlertidigalene/utils/SøknadUtils.kt
@@ -15,7 +15,7 @@ object SøknadUtils {
         språk = "nb",
         annenForelder = AnnenForelder(
             navn = "Berit",
-            fnr = "01017000299",
+            fnr = "23500180528",
             situasjon = Situasjon.FENGSEL,
             situasjonBeskrivelse = "Sitter i fengsel..",
             periodeOver6Måneder = false,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/api/domene/BarnTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/api/domene/BarnTest.kt
@@ -18,7 +18,7 @@ class BarnTest {
     @Test
     fun `Gyldig barn er gyldig`() {
         val gyldigBarn = Barn(
-            identitetsnummer = "01017000299",
+            identitetsnummer = "23500180528",
             fødselsdato = LocalDate.parse("2024-01-01"),
             aktørId = "12345",
             navn = "Barn Barnesen",
@@ -30,7 +30,7 @@ class BarnTest {
     @Test
     fun `Navnløse barn er ikke gyldig`() {
         val noname = Barn(
-            identitetsnummer = "01017000299",
+            identitetsnummer = "23500180528",
             fødselsdato = LocalDate.parse("2024-01-01"),
             aktørId = "12345",
             navn = "",
@@ -42,7 +42,7 @@ class BarnTest {
     @Test
     fun `Ufødte barn er ikke gyldig`() {
         val fremtidsbarn = Barn(
-            identitetsnummer = "01017000299",
+            identitetsnummer = "23500180528",
             fødselsdato = LocalDate.parse("2999-01-01"),
             aktørId = "12345",
             navn = "Barn Barnesen",
@@ -54,7 +54,7 @@ class BarnTest {
     @Test
     fun `Personer over 18 år er ikke gyldige barn`() {
         val voksen = Barn(
-            identitetsnummer = "01017000299",
+            identitetsnummer = "23500180528",
             fødselsdato = LocalDate.parse("1987-01-01"),
             aktørId = "12345",
             navn = "Indre Barnesen",
@@ -67,13 +67,13 @@ class BarnTest {
     fun `Det går an å kjøre valideringer på lister av barn`() {
         val flereBarn = listOf(
             Barn(
-                identitetsnummer = "01017000299",
+                identitetsnummer = "23500180528",
                 fødselsdato = LocalDate.parse("2999-01-01"),
                 aktørId = "12345",
                 navn = "Barn Barnesen",
                 type = TypeBarn.FRA_OPPSLAG
             ), Barn(
-                identitetsnummer = "01017000299",
+                identitetsnummer = "23500180528",
                 fødselsdato = LocalDate.parse("1987-01-01"),
                 aktørId = "12345",
                 navn = "Indre Barnesen",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/api/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/api/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
@@ -29,7 +29,7 @@ class OmsorgspengerUtbetalingArbeidstakerSøknadTest {
               "versjon": "1.1.0",
               "mottattDato": "2022-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "01017000299"
+                "norskIdentitetsnummer": "23500180528"
               },
               "ytelse": {
                 "type": "OMP_UT",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/kafka/OMPUtbetalingATSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/kafka/OMPUtbetalingATSøknadKonsumentTest.kt
@@ -116,7 +116,7 @@ class OMPUtbetalingATSøknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "1999-11-02",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "fosterbarn": [
             {
@@ -271,7 +271,7 @@ class OMPUtbetalingATSøknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "01017000299"
+              "norskIdentitetsnummer": "23500180528"
             },
             "ytelse": {
               "utenlandsopphold": {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/utils/OMPUtbetalingATSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingat/utils/OMPUtbetalingATSøknadUtils.kt
@@ -31,7 +31,7 @@ internal object OMPUtbetalingATSøknadUtils {
         mottatt = mottatt,
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "01017000299",
+            fødselsnummer = "23500180528",
             fødselsdato = LocalDate.parse("1999-11-02"),
             etternavn = "Nordmann",
             mellomnavn = null,
@@ -170,7 +170,7 @@ internal object OMPUtbetalingATSøknadUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("01017000299")),
+            K9Søker(NorskIdentitetsnummer.of("23500180528")),
             OmsorgspengerUtbetaling(
                 listOf(
                     Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("01010010007"))

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/api/domene/OmsorgspengerUtbetalingSnfSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/api/domene/OmsorgspengerUtbetalingSnfSøknadTest.kt
@@ -135,7 +135,7 @@ class OmsorgspengerUtbetalingSnfSøknadTest {
               "versjon": "1.1.0",
               "mottattDato": "2022-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "01017000299"
+                "norskIdentitetsnummer": "23500180528"
               },
               "ytelse": {
                 "type": "OMP_UT",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/kafka/OMPUtbetalingSNFSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/kafka/OMPUtbetalingSNFSøknadKonsumentTest.kt
@@ -109,7 +109,7 @@ class OMPUtbetalingSNFSøknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "2020-08-02",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "harDekketTiFørsteDagerSelv": true,
           "harSyktBarn": true,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/utils/OMPUtbetalingSNFSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/omsorgspengerutbetalingsnf/utils/OMPUtbetalingSNFSøknadUtils.kt
@@ -45,7 +45,7 @@ internal object OMPUtbetalingSNFSøknadUtils {
         mottatt = mottatt,
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "01017000299",
+            fødselsnummer = "23500180528",
             fødselsdato = LocalDate.parse("2020-08-02"),
             etternavn = "Nordmann",
             mellomnavn = "Mellomnavn",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/BarnTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/api/k9Format/BarnTest.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 class BarnTest {
     private companion object {
         val gyldigBarn = BarnDetaljer(
-            norskIdentifikator = "01017000299",
+            norskIdentifikator = "23500180528",
             fødselsdato = LocalDate.parse("2021-01-01"),
             aktørId = "10000001",
             navn = "Barnesen",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/OpplæringspengerSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/kafka/OpplæringspengerSøknadKonsumentTest.kt
@@ -498,7 +498,7 @@ class OpplæringspengerSøknadKonsumentTest : AbstractIntegrationTest() {
               "aktørId": "11111111111",
               "fødselsdato": null,
               "navn": "OLE DOLE",
-              "norskIdentifikator": "01017000299",
+              "norskIdentifikator": "23500180528",
               "årsakManglerIdentitetsnummer": null,
               "relasjonTilBarnet": "ANNET",
               "relasjonTilBarnetBeskrivelse": "Blaabla annet"

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/opplæringspenger/utils/OlpPdfSøknadUtils.kt
@@ -29,7 +29,7 @@ object OlpPdfSøknadUtils {
                 fødselsdato = LocalDate.parse("1990-09-29"),
             ),
             barn = Barn(
-                norskIdentifikator = "01017000299",
+                norskIdentifikator = "23500180528",
                 navn = "OLE DOLE",
                 aktørId = "11111111111",
                 relasjonTilBarnet = BarnRelasjon.ANNET,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/api/domene/PilsSøknadTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/api/domene/PilsSøknadTest.kt
@@ -203,7 +203,7 @@ class PilsSøknadTest {
               "versjon": "1.0.0",
               "mottattDato": "2022-01-02T03:04:05Z",
               "søker": {
-                "norskIdentitetsnummer": "01017000299"
+                "norskIdentitetsnummer": "23500180528"
               },
               "ytelse": {
                 "type": "PLEIEPENGER_LIVETS_SLUTTFASE",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/kafka/PleiepengerILivetsSluttfaseSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/kafka/PleiepengerILivetsSluttfaseSøknadKonsumentTest.kt
@@ -117,13 +117,13 @@ class PleiepengerILivetsSluttfaseSøknadKonsumentTest : AbstractIntegrationTest(
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "pleietrengende": {
             "fødselsdato": null,
             "navn": "Bjarne",
             "årsakManglerIdentitetsnummer": null,
-            "norskIdentitetsnummer": "01017000299"
+            "norskIdentitetsnummer": "23500180528"
           },
           "flereSokere": "JA",
           "selvstendigNæringsdrivende": {
@@ -316,7 +316,7 @@ class PleiepengerILivetsSluttfaseSøknadKonsumentTest : AbstractIntegrationTest(
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "01017000299"
+              "norskIdentitetsnummer": "23500180528"
             },
             "ytelse": {
               "arbeidstid": {
@@ -352,7 +352,7 @@ class PleiepengerILivetsSluttfaseSøknadKonsumentTest : AbstractIntegrationTest(
               },
               "pleietrengende": {
                 "fødselsdato": null,
-                "norskIdentitetsnummer": "01017000299"
+                "norskIdentitetsnummer": "23500180528"
               },
               "opptjeningAktivitet": {
                 "frilanser": {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/utils/PilsSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengerilivetssluttfase/utils/PilsSøknadUtils.kt
@@ -48,7 +48,7 @@ import no.nav.k9.søknad.ytelse.pls.v1.Pleietrengende as K9Pleietrengende
 object PilsSøknadUtils {
 
     fun gyldigSøknad(
-        søkerFødselsnummer: String = "01017000299",
+        søkerFødselsnummer: String = "23500180528",
         søknadId: String = UUID.randomUUID().toString(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC"))
     ) = PilsSøknadMottatt(
@@ -95,7 +95,7 @@ object PilsSøknadUtils {
         ),
         vedleggId = listOf("123", "456"),
         opplastetIdVedleggId = listOf("987"),
-        pleietrengende = Pleietrengende(norskIdentitetsnummer = "01017000299", navn = "Bjarne"),
+        pleietrengende = Pleietrengende(norskIdentitetsnummer = "23500180528", navn = "Bjarne"),
         medlemskap = Medlemskap(
             harBoddIUtlandetSiste12Mnd = true,
             utenlandsoppholdSiste12Mnd = listOf(
@@ -239,9 +239,9 @@ object PilsSøknadUtils {
         SøknadId(søknadId),
         Versjon("1.0.0"),
         mottatt,
-        K9Søker(NorskIdentitetsnummer.of("01017000299")),
+        K9Søker(NorskIdentitetsnummer.of("23500180528")),
         PleipengerLivetsSluttfase()
-            .medPleietrengende(K9Pleietrengende().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("01017000299")))
+            .medPleietrengende(K9Pleietrengende().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("23500180528")))
             .medUtenlandsopphold(
                 K9Utenlandsopphold()
                     .medPerioder(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/api/EndringsmeldingControllerTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/api/EndringsmeldingControllerTest.kt
@@ -63,7 +63,7 @@ class EndringsmeldingControllerTest {
     private lateinit var metrikkService: MetrikkService
 
     private companion object {
-        private val søkerMedBarn = "01017000299"
+        private val søkerMedBarn = "23500180528"
         private val barnIdentitetsnummer = "18909798651"
     }
 

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/kafka/PleiepengerSyktBarnEndringsmeldingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/kafka/PleiepengerSyktBarnEndringsmeldingKonsumentTest.kt
@@ -91,7 +91,7 @@ class PleiepengerSyktBarnEndringsmeldingKonsumentTest : AbstractIntegrationTest(
          {
             "søker": {
                "aktørId": "123456",
-               "fødselsnummer": "01017000299",
+               "fødselsnummer": "23500180528",
                "fødselsdato": "1999-11-02",
                "fornavn": "Ola",
                "mellomnavn": "Mellomnavn",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/utils/EndringsmeldingUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/endringsmelding/utils/EndringsmeldingUtils.kt
@@ -13,7 +13,7 @@ internal object EndringsmeldingUtils {
     internal fun defaultEndringsmelding(søknadsId: String, mottatt: ZonedDateTime) = PSBEndringsmeldingMottatt(
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "01017000299",
+            fødselsnummer = "23500180528",
             etternavn = "Nordmann",
             mellomnavn = "Mellomnavn",
             fornavn = "Ola",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/BarnValidationTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/BarnValidationTest.kt
@@ -10,7 +10,7 @@ class BarnValidationTest {
     private companion object {
         val felt = "barn"
         val gyldigBarn = BarnDetaljer(
-            fødselsnummer = "01017000299",
+            fødselsnummer = "23500180528",
             fødselsdato = LocalDate.parse("2021-01-01"),
             aktørId = "10000001",
             navn = "Barnesen",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SoknadValidationTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/api/domene/SoknadValidationTest.kt
@@ -84,7 +84,7 @@ class SoknadValidationTest {
         språk = Språk.nb,
         barn = BarnDetaljer(
             aktørId = null,
-            fødselsnummer = "01017000299",
+            fødselsnummer = "23500180528",
             fødselsdato = LocalDate.now(),
             navn = "Barn"
         ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/PleiepengerSyktBarnSøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/kafka/PleiepengerSyktBarnSøknadKonsumentTest.kt
@@ -89,14 +89,14 @@ class PleiepengerSyktBarnSøknadKonsumentTest : AbstractIntegrationTest() {
              "aktørId": "123456",
              "etternavn": "Nordmann",
              "fornavn": "Ola",
-             "fødselsnummer": "01017000299",
+             "fødselsnummer": "23500180528",
              "fødselsdato": "1999-11-02",
              "mellomnavn": "Mellomnavn"
            },
            "barn": {
              "aktørId": "11111111111",
              "fødselsdato": null,
-             "fødselsnummer": "01017000299",
+             "fødselsnummer": "23500180528",
              "navn": "Ole Dole",
              "årsakManglerIdentitetsnummer": null
            },

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/søknad/pdf/PSBSøknadPdfGeneratorTest.kt
@@ -89,7 +89,7 @@ class PSBSøknadPdfGeneratorTest {
                     fødselsdato = LocalDate.parse("1990-09-29"),
                 ),
                 barn = Barn(
-                    fødselsnummer = "01017000299",
+                    fødselsnummer = "23500180528",
                     navn = "OLE DOLE",
                     aktørId = "11111111111"
                 ),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/utils/PSBSøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/pleiepengersyktbarn/utils/PSBSøknadUtils.kt
@@ -47,7 +47,7 @@ internal object PSBSøknadUtils {
         tilOgMed = LocalDate.parse("2021-01-01"),
         søker = Søker(
             aktørId = "123456",
-            fødselsnummer = "01017000299",
+            fødselsnummer = "23500180528",
             etternavn = "Nordmann",
             mellomnavn = "Mellomnavn",
             fornavn = "Ola",
@@ -55,7 +55,7 @@ internal object PSBSøknadUtils {
         ),
         barn = Barn(
             navn = "Ole Dole",
-            fødselsnummer = "01017000299",
+            fødselsnummer = "23500180528",
             aktørId = "11111111111"
         ),
         vedleggId = listOf("123", "456"),

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseInntektRapporteringKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseInntektRapporteringKonsumentTest.kt
@@ -154,7 +154,7 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "oppgittInntektForPeriode": {
                 "arbeidstakerOgFrilansInntekt": 6000,
@@ -175,7 +175,7 @@ class UngdomsytelseInntektRapporteringKonsumentTest : AbstractIntegrationTest() 
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "01017000299"
+              "norskIdentitetsnummer": "23500180528"
             },
             "ytelse": {
               "type": "UNGDOMSYTELSE",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
@@ -167,7 +167,7 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "språk": "nb",
           "dokumentId": [
@@ -182,7 +182,7 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
             "språk": "nb",
             "mottattDato": "$mottatt",
             "søker": {
-              "norskIdentitetsnummer": "01017000299"
+              "norskIdentitetsnummer": "23500180528"
             },
             "bekreftelse": {
               "type": "UNG_ENDRET_STARTDATO",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelsesøknadKonsumentTest.kt
@@ -149,7 +149,7 @@ class UngdomsytelsesøknadKonsumentTest : AbstractIntegrationTest() {
             "aktørId": "123456",
             "fødselsdato": "2000-01-01",
             "fornavn": "Ola",
-            "fødselsnummer": "01017000299"
+            "fødselsnummer": "23500180528"
           },
           "startdato": "2022-01-01",
           "barn": [
@@ -178,7 +178,7 @@ class UngdomsytelsesøknadKonsumentTest : AbstractIntegrationTest() {
             "mottattDato": "$mottatt",
             "søknadId": "$søknadId",
             "søker": {
-              "norskIdentitetsnummer": "01017000299"
+              "norskIdentitetsnummer": "23500180528"
             },
             "ytelse": {
               "type": "UNGDOMSYTELSE",

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/InntektrapporteringUtils.kt
@@ -29,7 +29,7 @@ object InntektrapporteringUtils {
     )
 
     fun gyldigInntektsrapportering(
-        søkerFødselsnummer: String = "01017000299",
+        søkerFødselsnummer: String = "23500180528",
         søknadId: String = UUID.randomUUID().toString(),
         deltakelseId: UUID = UUID.randomUUID(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
@@ -73,7 +73,7 @@ object InntektrapporteringUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("01017000299")),
+            K9Søker(NorskIdentitetsnummer.of("23500180528")),
             ytelse
 
         ).medKildesystem(Kildesystem.SØKNADSDIALOG)

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelseOppgavebekreftelseUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelseOppgavebekreftelseUtils.kt
@@ -18,7 +18,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 object UngdomsytelseOppgavebekreftelseUtils {
 
     fun oppgavebekreftelseMottatt(
-        søkerFødselsnummer: String = "01017000299",
+        søkerFødselsnummer: String = "23500180528",
         oppgaveReferanse: String = UUID.randomUUID().toString(),
         oppgave: KomplettUngdomsytelseOppgaveDTO = KomplettEndretStartdatoUngdomsytelseOppgaveDTO(
             oppgaveReferanse = oppgaveReferanse,
@@ -55,7 +55,7 @@ object UngdomsytelseOppgavebekreftelseUtils {
             .medSøknadId(søknadId)
             .medVersjon("1.0.0")
             .medMottattDato(mottatt)
-            .medSøker(K9Søker(NorskIdentitetsnummer.of("01017000299")))
+            .medSøker(K9Søker(NorskIdentitetsnummer.of("23500180528")))
             .medBekreftelse(bekreftelse)
             .medKildesystem(Kildesystem.SØKNADSDIALOG)
     }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/utils/UngdomsytelsesøknadUtils.kt
@@ -21,7 +21,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 object UngdomsytelsesøknadUtils {
 
     fun gyldigSøknad(
-        søkerFødselsnummer: String = "01017000299",
+        søkerFødselsnummer: String = "23500180528",
         søknadId: String = UUID.randomUUID().toString(),
         mottatt: ZonedDateTime = ZonedDateTime.of(2018, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC")),
         deltakelseId: UUID = UUID.randomUUID(),
@@ -73,7 +73,7 @@ object UngdomsytelsesøknadUtils {
             SøknadId(søknadId),
             Versjon("1.0.0"),
             mottatt,
-            K9Søker(NorskIdentitetsnummer.of("01017000299")),
+            K9Søker(NorskIdentitetsnummer.of("23500180528")),
             ytelse
 
         ).medKildesystem(Kildesystem.SØKNADSDIALOG)


### PR DESCRIPTION
Erstatter gamle fiktive FNR brukt i tester med nytt fiktivt syntetiske personnummer (23500180528) som automatisk ignoreres av sif-code-scan.

Relatert til navikt/sif-gha-workflows#280