### PR TITLE
TSFF-2654 - feat(ungdomsytelse): legg til støtte for opphør ved maksdato i oppgavebekreftelse

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,9 +33,9 @@ repositories {
 
 val tokenSupportVersion = "6.0.7"
 val jsonassertVersion = "1.5.3"
-val k9FormatVersion = "13.2.0"
+val k9FormatVersion = "13.2.2"
 val ungDeltakelseOpplyserVersjon = "2.11.2"
-val ungBrukerdialigApiVersjon = "1.0.3"
+val ungBrukerdialigApiVersjon = "1.0.4"
 val springMockkVersion = "5.0.1"
 val logstashLogbackEncoderVersion = "9.0"
 val openhtmltopdfVersion = "1.1.4"

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse
 import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse
+import no.nav.k9.oppgave.bekreftelse.ung.opphor.OpphørVedMaksdatoBekreftelse
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretPeriodeBekreftelse
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretSluttdatoBekreftelse
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretStartdatoBekreftelse
@@ -24,6 +25,7 @@ import java.util.*
     JsonSubTypes.Type(value = KomplettEndretSluttdatoUngdomsytelseOppgaveDTO::class, name = Bekreftelse.UNG_ENDRET_SLUTTDATO),
     JsonSubTypes.Type(value = KomplettEndretPeriodeUngdomsytelseOppgaveDTO::class, name = Bekreftelse.UNG_ENDRET_PERIODE),
     JsonSubTypes.Type(value = KomplettKontrollerRegisterInntektOppgaveTypeDataDTO::class, name = Bekreftelse.UNG_AVVIK_REGISTERINNTEKT),
+    JsonSubTypes.Type(value = KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO::class, name = Bekreftelse.UNG_OPPHOR_VED_MAKSDATO),
 )
 sealed class KomplettUngdomsytelseOppgaveDTO(
     open val oppgaveReferanse: String,
@@ -160,3 +162,37 @@ data class KomplettKontrollerRegisterInntektOppgaveTypeDataDTO(
         )
     }
 }
+
+data class KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+    override val oppgaveReferanse: String,
+    override val uttalelse: UngdomsytelseOppgaveUttalelseDTO,
+    val sluttdato: LocalDate,
+    val maxDato: LocalDate,
+) : KomplettUngdomsytelseOppgaveDTO(oppgaveReferanse, uttalelse) {
+
+    override fun somK9Format(): Bekreftelse {
+        val bekreftelse = OpphørVedMaksdatoBekreftelse(
+            UUID.fromString(oppgaveReferanse),
+            sluttdato,
+            uttalelse.harUttalelse
+        )
+
+        return if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
+            bekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
+        } else {
+            bekreftelse
+        }
+    }
+
+    override fun dokumentTittelSuffix(): String = "opphor ved maksdato"
+
+    override fun somKomplettOppgave(oppgaveDTO: BrukerdialogOppgaveDto): KomplettUngdomsytelseOppgaveDTO {
+        return KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+            oppgaveReferanse = oppgaveReferanse,
+            sluttdato = sluttdato,
+            maxDato = maxDato,
+            uttalelse = uttalelse
+        )
+    }
+}
+

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
@@ -184,7 +184,7 @@ data class KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
         }
     }
 
-    override fun dokumentTittelSuffix(): String = "opphor ved maksdato"
+    override fun dokumentTittelSuffix(): String = "opphør ved maksdato"
 
     override fun somKomplettOppgave(oppgaveDTO: BrukerdialogOppgaveDto): KomplettUngdomsytelseOppgaveDTO {
         return KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
@@ -167,7 +167,7 @@ data class KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
     override val oppgaveReferanse: String,
     override val uttalelse: UngdomsytelseOppgaveUttalelseDTO,
     val sluttdato: LocalDate,
-    val maxDato: LocalDate,
+    val maksdato: LocalDate,
 ) : KomplettUngdomsytelseOppgaveDTO(oppgaveReferanse, uttalelse) {
 
     override fun somK9Format(): Bekreftelse {
@@ -177,10 +177,10 @@ data class KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
             uttalelse.harUttalelse
         )
 
-        return if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
-            bekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
-        } else {
+        return if (uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
             bekreftelse
+        } else {
+            bekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
         }
     }
 
@@ -190,7 +190,7 @@ data class KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
         return KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
             oppgaveReferanse = oppgaveReferanse,
             sluttdato = sluttdato,
-            maxDato = maxDato,
+            maksdato = maksdato,
             uttalelse = uttalelse
         )
     }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
@@ -25,7 +25,7 @@ import java.util.*
     JsonSubTypes.Type(value = KomplettEndretSluttdatoUngdomsytelseOppgaveDTO::class, name = Bekreftelse.UNG_ENDRET_SLUTTDATO),
     JsonSubTypes.Type(value = KomplettEndretPeriodeUngdomsytelseOppgaveDTO::class, name = Bekreftelse.UNG_ENDRET_PERIODE),
     JsonSubTypes.Type(value = KomplettKontrollerRegisterInntektOppgaveTypeDataDTO::class, name = Bekreftelse.UNG_AVVIK_REGISTERINNTEKT),
-    JsonSubTypes.Type(value = KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO::class, name = Bekreftelse.UNG_OPPHOR_VED_MAKSDATO),
+    JsonSubTypes.Type(value = KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO::class, name = Bekreftelse.UNG_OPPHOR_VED_MAKSDATO),
 )
 sealed class KomplettUngdomsytelseOppgaveDTO(
     open val oppgaveReferanse: String,
@@ -163,7 +163,7 @@ data class KomplettKontrollerRegisterInntektOppgaveTypeDataDTO(
     }
 }
 
-data class KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+data class KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO(
     override val oppgaveReferanse: String,
     override val uttalelse: UngdomsytelseOppgaveUttalelseDTO,
     val sluttdato: LocalDate,
@@ -187,7 +187,7 @@ data class KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
     override fun dokumentTittelSuffix(): String = "opphør ved maksdato"
 
     override fun somKomplettOppgave(oppgaveDTO: BrukerdialogOppgaveDto): KomplettUngdomsytelseOppgaveDTO {
-        return KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+        return KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO(
             oppgaveReferanse = oppgaveReferanse,
             sluttdato = sluttdato,
             maksdato = maksdato,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgaveDTO.kt
@@ -55,7 +55,7 @@ data class UngdomsytelseOppgaveDTO(
             }
 
             is BekreftOpphorVedMaksdatoOppgavetypeDataDto -> {
-                KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+                KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO(
                     oppgaveReferanse = oppgaveReferanse,
                     sluttdato = oppgavetypeData.sluttdato,
                     maksdato = oppgavetypeData.maxDato,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgaveDTO.kt
@@ -8,6 +8,7 @@ import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretperiode.EndretPerio
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretsluttdato.EndretSluttdatoDataDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretstartdato.EndretStartdatoDataDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.KontrollerRegisterinntektOppgavetypeDataDto
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.opphorvedmaksdato.BekreftOpphorVedMaksdatoOppgavetypeDataDto
 import org.hibernate.validator.constraints.UUID
 
 
@@ -49,6 +50,15 @@ data class UngdomsytelseOppgaveDTO(
                     fraOgMed = oppgavetypeData.fraOgMed,
                     tilOgMed = oppgavetypeData.tilOgMed,
                     registerinntekt = oppgavetypeData.registerinntekt,
+                    uttalelse = uttalelse
+                )
+            }
+
+            is BekreftOpphorVedMaksdatoOppgavetypeDataDto -> {
+                KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+                    oppgaveReferanse = oppgaveReferanse,
+                    sluttdato = oppgavetypeData.sluttdato,
+                    maxDato = oppgavetypeData.maxDato,
                     uttalelse = uttalelse
                 )
             }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/UngdomsytelseOppgaveDTO.kt
@@ -58,7 +58,7 @@ data class UngdomsytelseOppgaveDTO(
                 KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
                     oppgaveReferanse = oppgaveReferanse,
                     sluttdato = oppgavetypeData.sluttdato,
-                    maxDato = oppgavetypeData.maxDato,
+                    maksdato = oppgavetypeData.maxDato,
                     uttalelse = uttalelse
                 )
             }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
@@ -74,6 +74,16 @@ class UngdomsytelseOppgavebekreftelsePdfData(private val oppgavebekreftelseMotta
             )
 
             else -> null
+        },
+
+        "opphorVedMaksdatoOppgave" to when (this) {
+            is KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO -> mapOf(
+                "sluttdato" to DATE_FORMATTER.format(sluttdato),
+                "maxDato" to DATE_FORMATTER.format(maxDato),
+                "spørsmål" to "Har du tilbakemelding på at ungdomsprogrammet opphører ved maksdato ${DATE_FORMATTER.format(maxDato)}?"
+            )
+
+            else -> null
         }
     )
 

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
@@ -76,11 +76,11 @@ class UngdomsytelseOppgavebekreftelsePdfData(private val oppgavebekreftelseMotta
             else -> null
         },
 
-        "opphorVedMaksdatoOppgave" to when (this) {
+        "opphørVedMaksdatoOppgave" to when (this) {
             is KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO -> mapOf(
                 "sluttdato" to DATE_FORMATTER.format(sluttdato),
-                "maxDato" to DATE_FORMATTER.format(maxDato),
-                "spørsmål" to "Har du tilbakemelding på at ungdomsprogrammet opphører ved maksdato ${DATE_FORMATTER.format(maxDato)}?"
+                "maksdato" to DATE_FORMATTER.format(maksdato),
+                "spørsmål" to "Mener du at sluttdatoen eller maksdatoen er feil?"
             )
 
             else -> null

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
@@ -77,7 +77,7 @@ class UngdomsytelseOppgavebekreftelsePdfData(private val oppgavebekreftelseMotta
         },
 
         "opphørVedMaksdatoOppgave" to when (this) {
-            is KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO -> mapOf(
+            is KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO -> mapOf(
                 "sluttdato" to DATE_FORMATTER.format(sluttdato),
                 "maksdato" to DATE_FORMATTER.format(maksdato),
                 "spørsmål" to "Mener du at sluttdatoen eller maksdatoen er feil?"

--- a/src/main/resources/handlebars/ungdomsytelse-oppgave-bekreftelse.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-oppgave-bekreftelse.hbs
@@ -14,6 +14,7 @@
         <bookmark name="Godkjenne endret sluttdato" href="#endretSluttdato"/>
         <bookmark name="Godkjenne endret periode" href="#endretPeriode"/>
         <bookmark name="Kontrollere inntekt fra register" href="#kontrollerRegisterInntektOppgave"/>
+        <bookmark name="Opphør ved maksdato" href="#opphorVedMaksdato"/>
     </bookmarks>
     {{#block 'style-common' }}
     {{/block}}
@@ -116,6 +117,21 @@
                     spørsmålstekstUttalelse=oppgave.kontrollerRegisterInntektOppgave.spørsmål
             }}
 
+        </section>
+    {{/if}}
+
+    {{#if oppgave.opphorVedMaksdatoOppgave}}
+        <section id="opphorVedMaksdato">
+            <h2>Opphør ved maksdato i ungdomsprogrammet</h2>
+
+            <p>Opphør av ungdomsprogrammet er satt til {{oppgave.opphorVedMaksdatoOppgave.sluttdato}}.</p>
+            <p>Maksdato for deltakelsen er {{oppgave.opphorVedMaksdatoOppgave.maxDato}}.</p>
+
+            <br/>
+            {{> partial/ung/uttalelsePartial
+                    uttalelse=oppgave.uttalelse
+                    spørsmålstekstUttalelse=oppgave.opphorVedMaksdatoOppgave.spørsmål
+            }}
         </section>
     {{/if}}
 </div>

--- a/src/main/resources/handlebars/ungdomsytelse-oppgave-bekreftelse.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-oppgave-bekreftelse.hbs
@@ -14,7 +14,7 @@
         <bookmark name="Godkjenne endret sluttdato" href="#endretSluttdato"/>
         <bookmark name="Godkjenne endret periode" href="#endretPeriode"/>
         <bookmark name="Kontrollere inntekt fra register" href="#kontrollerRegisterInntektOppgave"/>
-        <bookmark name="Opphør ved maksdato" href="#opphorVedMaksdato"/>
+        <bookmark name="Ungdomsytelsen stopper ved maksdato" href="#ytelsenStopperVedMaksdato"/>
     </bookmarks>
     {{#block 'style-common' }}
     {{/block}}
@@ -120,17 +120,17 @@
         </section>
     {{/if}}
 
-    {{#if oppgave.opphorVedMaksdatoOppgave}}
-        <section id="opphorVedMaksdato">
-            <h2>Opphør ved maksdato i ungdomsprogrammet</h2>
+    {{#if oppgave.opphørVedMaksdatoOppgave}}
+        <section id="ytelsenStopperVedMaksdato">
+            <h2>Ungdomsytelsen stopper ved maksdato</h2>
 
-            <p>Opphør av ungdomsprogrammet er satt til {{oppgave.opphorVedMaksdatoOppgave.sluttdato}}.</p>
-            <p>Maksdato for deltakelsen er {{oppgave.opphorVedMaksdatoOppgave.maxDato}}.</p>
+            <p>Siste dag du får ungdomsytelse er {{oppgave.opphørVedMaksdatoOppgave.sluttdato}}.</p>
+            <p>Maksdatoen din er {{oppgave.opphørVedMaksdatoOppgave.maksdato}}.</p>
 
             <br/>
             {{> partial/ung/uttalelsePartial
                     uttalelse=oppgave.uttalelse
-                    spørsmålstekstUttalelse=oppgave.opphorVedMaksdatoOppgave.spørsmål
+                    spørsmålstekstUttalelse=oppgave.opphørVedMaksdatoOppgave.spørsmål
             }}
         </section>
     {{/if}}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseControllerTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/UngdomsytelseControllerTest.kt
@@ -26,8 +26,8 @@ import no.nav.ung.brukerdialog.kontrakt.oppgaver.BrukerdialogOppgaveDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveType
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveYtelsetype
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgavetypeDataDto
-import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretstartdato.EndretStartdatoDataDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.inntektsrapportering.InntektsrapporteringOppgavetypeDataDto
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.opphorvedmaksdato.BekreftOpphorVedMaksdatoOppgavetypeDataDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.søkytelse.SøkYtelseOppgavetypeDataDto
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseDTO
@@ -229,10 +229,10 @@ class UngdomsytelseControllerTest {
         coEvery { innsendingService.registrer(any(), any()) } returns Unit
         every { metrikkService.registrerMottattInnsending(any()) } returns Unit
         mockHentingAvOppgave(
-            oppgavetype = OppgaveType.BEKREFT_ENDRET_STARTDATO,
-            oppgavetypeData = EndretStartdatoDataDto(
-                LocalDate.now(),
-                LocalDate.now().minusDays(30)
+            oppgavetype = OppgaveType.BEKREFT_OPPHOR_VED_MAKSDATO,
+            oppgavetypeData = BekreftOpphorVedMaksdatoOppgavetypeDataDto(
+                LocalDate.now().minusDays(1),
+                LocalDate.now()
             )
         )
 

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
@@ -117,7 +117,7 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
                     uttalelseFraDeltaker = null
                 ),
                 sluttdato = LocalDate.parse("2025-12-01"),
-                maxDato = LocalDate.parse("2025-12-01")
+                maksdato = LocalDate.parse("2025-12-01")
             ),
             mottatt = mottatt
         )
@@ -169,7 +169,7 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
                 "uttalelseFraDeltaker": null
             },
             "sluttdato": "2025-12-01",
-            "maxDato": "2025-12-01"
+            "maksdato": "2025-12-01"
           },
           "mottatt": "$mottatt",
           "søker": {

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
@@ -14,11 +14,12 @@ import no.nav.brukerdialog.utils.NavHeaders
 import no.nav.brukerdialog.utils.TokenTestUtils.hentToken
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveUttalelseDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.oppgavebekreftelse.UngdomsytelseOppgavebekreftelseTopologyConfiguration
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.SøknadUtils
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelseOppgavebekreftelseUtils
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveType
-import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretstartdato.EndretStartdatoDataDto
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.opphorvedmaksdato.BekreftOpphorVedMaksdatoOppgavetypeDataDto
 import org.intellij.lang.annotations.Language
 import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
@@ -47,10 +48,10 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
         mockLagreDokument()
         mockJournalføring()
         mockHentingAvOppgave(
-            oppgavetype = OppgaveType.BEKREFT_ENDRET_STARTDATO,
-            oppgavetypeData = EndretStartdatoDataDto(
+            oppgavetype = OppgaveType.BEKREFT_OPPHOR_VED_MAKSDATO,
+            oppgavetypeData = BekreftOpphorVedMaksdatoOppgavetypeDataDto(
                 LocalDate.now(),
-                LocalDate.now().minusMonths(1)
+                LocalDate.now().plusDays(1)
             )
         )
         mockMarkerOppgaveSomLøst()
@@ -109,6 +110,15 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
         val mottatt = ZonedDateTime.parse(mottattString, JacksonConfiguration.zonedDateTimeFormatter)
         val oppgavebekreftelseMottatt = UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt(
             oppgaveReferanse = oppgaveReferanse,
+            oppgave = KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+                oppgaveReferanse = oppgaveReferanse,
+                uttalelse = UngdomsytelseOppgaveUttalelseDTO(
+                    harUttalelse = false,
+                    uttalelseFraDeltaker = null
+                ),
+                sluttdato = LocalDate.parse("2025-12-01"),
+                maxDato = LocalDate.parse("2025-12-01")
+            ),
             mottatt = mottatt
         )
         val correlationId = UUID.randomUUID().toString()
@@ -152,13 +162,14 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
     private fun preprosessertSøknadSomJson(oppgaveReferanse: String, mottatt: String) = """
         {
           "oppgave": {
-            "type": "UNG_ENDRET_STARTDATO",
+            "type": "UNG_OPPHOR_VED_MAKSDATO",
             "oppgaveReferanse": "$oppgaveReferanse",
             "uttalelse": {
                 "harUttalelse": false,
                 "uttalelseFraDeltaker": null
             },
-            "nyStartdato": "2025-12-01"
+            "sluttdato": "2025-12-01",
+            "maxDato": "2025-12-01"
           },
           "mottatt": "$mottatt",
           "søker": {
@@ -185,8 +196,8 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
               "norskIdentitetsnummer": "23500180528"
             },
             "bekreftelse": {
-              "type": "UNG_ENDRET_STARTDATO",
-              "nyStartdato": "2025-12-01",
+              "type": "UNG_OPPHOR_VED_MAKSDATO",
+              "sluttdato": "2025-12-01",
               "oppgaveReferanse": "$oppgaveReferanse",
               "uttalelseFraBruker": null,
               "harUttalelse": false,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
@@ -14,7 +14,7 @@ import no.nav.brukerdialog.utils.NavHeaders
 import no.nav.brukerdialog.utils.TokenTestUtils.hentToken
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveUttalelseDTO
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.oppgavebekreftelse.UngdomsytelseOppgavebekreftelseTopologyConfiguration
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.SøknadUtils
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelseOppgavebekreftelseUtils
@@ -110,7 +110,7 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
         val mottatt = ZonedDateTime.parse(mottattString, JacksonConfiguration.zonedDateTimeFormatter)
         val oppgavebekreftelseMottatt = UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt(
             oppgaveReferanse = oppgaveReferanse,
-            oppgave = KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+            oppgave = KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO(
                 oppgaveReferanse = oppgaveReferanse,
                 uttalelse = UngdomsytelseOppgaveUttalelseDTO(
                     harUttalelse = false,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsyteleOppgavebekreftelsePdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsyteleOppgavebekreftelsePdfGeneratorTest.kt
@@ -6,7 +6,7 @@ import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.Ko
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretSluttdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretStartdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettKontrollerRegisterInntektOppgaveTypeDataDTO
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveUttalelseDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelseOppgavebekreftelseUtils
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretperiode.PeriodeDTO
@@ -279,7 +279,7 @@ class UngdomsyteleOppgavebekreftelsePdfGeneratorTest {
             pdf = generator.genererPDF(
                 UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt()
                     .copy(
-                        oppgave = KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+                        oppgave = KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO(
                             oppgaveReferanse = UUID.randomUUID().toString(),
                             uttalelse = UngdomsytelseOppgaveUttalelseDTO(
                                 harUttalelse = true,

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsyteleOppgavebekreftelsePdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsyteleOppgavebekreftelsePdfGeneratorTest.kt
@@ -6,6 +6,7 @@ import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.Ko
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretSluttdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretStartdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettKontrollerRegisterInntektOppgaveTypeDataDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveUttalelseDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelseOppgavebekreftelseUtils
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.endretperiode.PeriodeDTO
@@ -269,6 +270,23 @@ class UngdomsyteleOppgavebekreftelsePdfGeneratorTest {
                                 LocalDate.parse("2025-01-01"),
                                 null
                             )
+                        )
+                    ).pdfData()
+            )
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+            id = "13-opphor-ved-maksdato"
+            pdf = generator.genererPDF(
+                UngdomsytelseOppgavebekreftelseUtils.oppgavebekreftelseMottatt()
+                    .copy(
+                        oppgave = KomplettOpphorVedMaksdatoUngdomsytelseOppgaveDTO(
+                            oppgaveReferanse = UUID.randomUUID().toString(),
+                            uttalelse = UngdomsytelseOppgaveUttalelseDTO(
+                                harUttalelse = true,
+                                uttalelseFraDeltaker = "Jeg mener opphørsdatoen er satt for tidlig"
+                            ),
+                            sluttdato = LocalDate.parse("2025-12-31"),
+                            maxDato = LocalDate.parse("2026-01-15")
                         )
                     ).pdfData()
             )

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsyteleOppgavebekreftelsePdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsyteleOppgavebekreftelsePdfGeneratorTest.kt
@@ -286,7 +286,7 @@ class UngdomsyteleOppgavebekreftelsePdfGeneratorTest {
                                 uttalelseFraDeltaker = "Jeg mener opphørsdatoen er satt for tidlig"
                             ),
                             sluttdato = LocalDate.parse("2025-12-31"),
-                            maxDato = LocalDate.parse("2026-01-15")
+                            maksdato = LocalDate.parse("2026-01-15")
                         )
                     ).pdfData()
             )


### PR DESCRIPTION
### Behov / Bakgrunn

Når ungdomsprogramytelsen nærmer seg maksdato (260/300 virkedager) skal deltaker varsles 4 uker før, og gis mulighet til å gi kommentar før ytelsen automatisk opphører.

### Løsning

Denne PR-en legger til støtte i `k9-brukerdialog-prosessering` for ny oppgavebekreftelse: `OpphørVedMaksdatoBekreftelse`.

- **Innsending/mapping**
  - Utvidet mapping i `UngdomsytelseOppgaveDTO` for ny oppgavetype `BekreftOpphorVedMaksdatoOppgavetypeDataDto`.
  - Lagt til ny komplett DTO (`KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO`) med feltene `sluttdato` og `maxdato`.
- **K9-format**
  - Mapper til `OpphørVedMaksdatoBekreftelse` med støtte for uttalelse fra deltaker.
- **PDF**
  - Oppdatert `UngdomsytelseOppgavebekreftelsePdfData` med felt for opphør ved maksdato.
  - Oppdatert `ungdomsytelse-oppgave-bekreftelse.hbs` med egen seksjon og bookmark for opphør ved maksdato.
- **Verifisering**
  - Oppdatert relevante tester for controller, Kafka-flyt og PDF-generering.

### Andre endringer

- Justert testforventninger og testdata for ny oppgavetype i:
  - `UngdomsytelseControllerTest`
  - `UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest`
  - `UngdomsyteleOppgavebekreftelsePdfGeneratorTest`
- Fjernet ubrukt import i testkode etter oppdatering av oppgavetype-scenario.