### PR TITLE
Chore: Fiks pdf warning

### DIFF
--- a/src/main/resources/handlebars/aktivitetspenger-rapportering-soknad.hbs
+++ b/src/main/resources/handlebars/aktivitetspenger-rapportering-soknad.hbs
@@ -32,7 +32,7 @@
             {{#each inntektForPeriode as |inntekt|}}
                <li class="li-style-none"> I perioden <strong>{{inntekt.periode.fraOgMed}} til {{inntekt.periode.tilOgMed}}</strong> har du oppgitt følgende
                    lønn:</li>
-                <br/>
+                <li class="li-style-none"><br/></li>
                 {{#if inntekt.arbeidstakerOgFrilansInntekt}}
                     <li class="li-style-none"><strong>Lønn (før skatt):</strong> {{inntekt.arbeidstakerOgFrilansInntekt}}</li>
                 {{/if}}

--- a/src/main/resources/handlebars/ungdomsytelse-rapportering-soknad.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-rapportering-soknad.hbs
@@ -32,7 +32,7 @@
             {{#each inntektForPeriode as |inntekt|}}
                <li class="li-style-none"> I perioden <strong>{{inntekt.periode.fraOgMed}} til {{inntekt.periode.tilOgMed}}</strong> har du oppgitt følgende
                    lønn:</li>
-                <br/>
+                <li class="li-style-none"><br/></li>
                 {{#if inntekt.arbeidstakerOgFrilansInntekt}}
                     <li class="li-style-none"><strong>Lønn (før skatt):</strong> {{inntekt.arbeidstakerOgFrilansInntekt}}</li>
                 {{/if}}

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/pdf/AktivitetspengerInntektsrapporteringPdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/pdf/AktivitetspengerInntektsrapporteringPdfGeneratorTest.kt
@@ -22,7 +22,7 @@ class AktivitetspengerInntektsrapporteringPdfGeneratorTest {
     }
 
     private companion object {
-        const val PDF_PREFIX = "ung"
+        const val PDF_PREFIX = "aktivitetspenger-inntekt"
         val generator = PDFGenerator()
 
         fun genererOppsummeringsPdfer(writeBytes: Boolean) {


### PR DESCRIPTION
### Behov / Bakgrunn
Vi får en del støy i loggene som følge av at html-en ikke er helt riktig satt opp.

### Løsning
Wrapepr br i en li inne i ul. 

### Andre endringer
Bruker dokumentprefiks itesten for aktivitetspenger 
