### PR TITLE
TSFF-2756 - feilfiks uttalelseFraBruker

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/api/domene/oppgavebekreftelse/KomplettUngdomsytelseOppgaveDTO.kt
@@ -41,20 +41,14 @@ data class KomplettEndretStartdatoUngdomsytelseOppgaveDTO(
     override val uttalelse: UngdomsytelseOppgaveUttalelseDTO,
     val nyStartdato: LocalDate,
 ) : KomplettUngdomsytelseOppgaveDTO(oppgaveReferanse, uttalelse) {
-    override fun somK9Format(): Bekreftelse {
-        val endretFomDatoBekreftelse =
-            EndretStartdatoBekreftelse(
-                UUID.fromString(oppgaveReferanse),
-                nyStartdato,
-                uttalelse.harUttalelse
-            )
-
-        if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
-            endretFomDatoBekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
-        }
-
-        return endretFomDatoBekreftelse
-    }
+    override fun somK9Format(): Bekreftelse =
+        EndretStartdatoBekreftelse(
+            UUID.fromString(oppgaveReferanse),
+            nyStartdato,
+            uttalelse.harUttalelse,
+            if (uttalelse.uttalelseFraDeltaker.isNullOrBlank()) null else uttalelse.uttalelseFraDeltaker,
+            null
+        )
 
     override fun dokumentTittelSuffix(): String = "endret startdato"
 
@@ -72,20 +66,14 @@ data class KomplettEndretSluttdatoUngdomsytelseOppgaveDTO(
     override val uttalelse: UngdomsytelseOppgaveUttalelseDTO,
     val nySluttdato: LocalDate,
 ) : KomplettUngdomsytelseOppgaveDTO(oppgaveReferanse, uttalelse) {
-    override fun somK9Format(): Bekreftelse {
-        val endretFomDatoBekreftelse =
-            EndretSluttdatoBekreftelse(
-                UUID.fromString(oppgaveReferanse),
-                nySluttdato,
-                uttalelse.harUttalelse
-            )
-
-        if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
-            endretFomDatoBekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
-        }
-
-        return endretFomDatoBekreftelse
-    }
+    override fun somK9Format(): Bekreftelse =
+        EndretSluttdatoBekreftelse(
+            UUID.fromString(oppgaveReferanse),
+            nySluttdato,
+            uttalelse.harUttalelse,
+            if (uttalelse.uttalelseFraDeltaker.isNullOrBlank()) null else uttalelse.uttalelseFraDeltaker,
+            null
+        )
 
     override fun dokumentTittelSuffix(): String = "endret sluttdato"
 
@@ -103,20 +91,15 @@ data class KomplettEndretPeriodeUngdomsytelseOppgaveDTO(
     override val uttalelse: UngdomsytelseOppgaveUttalelseDTO,
     val nyPeriode: PeriodeDTO?,
 ) : KomplettUngdomsytelseOppgaveDTO(oppgaveReferanse, uttalelse) {
-    override fun somK9Format(): Bekreftelse {
-        val endretPeriodeBekreftelse =
-            EndretPeriodeBekreftelse(
-                UUID.fromString(oppgaveReferanse),
-                nyPeriode?.let { Periode(nyPeriode.fomDato, nyPeriode.tomDato) },
-                uttalelse.harUttalelse
-            )
+    override fun somK9Format(): Bekreftelse =
+        EndretPeriodeBekreftelse(
+            UUID.fromString(oppgaveReferanse),
+            nyPeriode?.let { Periode(nyPeriode.fomDato, nyPeriode.tomDato) },
+            uttalelse.harUttalelse,
+            if (uttalelse.uttalelseFraDeltaker.isNullOrBlank()) null else uttalelse.uttalelseFraDeltaker,
+            null
+        )
 
-        if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
-            endretPeriodeBekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
-        }
-
-        return endretPeriodeBekreftelse
-    }
 
     override fun dokumentTittelSuffix(): String = "endret periode"
 
@@ -170,19 +153,14 @@ data class KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO(
     val maksdato: LocalDate,
 ) : KomplettUngdomsytelseOppgaveDTO(oppgaveReferanse, uttalelse) {
 
-    override fun somK9Format(): Bekreftelse {
-        val bekreftelse = OpphørVedMaksdatoBekreftelse(
+    override fun somK9Format(): Bekreftelse =
+        OpphørVedMaksdatoBekreftelse(
             UUID.fromString(oppgaveReferanse),
             sluttdato,
-            uttalelse.harUttalelse
+            uttalelse.harUttalelse,
+            if (uttalelse.uttalelseFraDeltaker.isNullOrBlank()) null else uttalelse.uttalelseFraDeltaker,
+            null
         )
-
-        return if (uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
-            bekreftelse
-        } else {
-            bekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
-        }
-    }
 
     override fun dokumentTittelSuffix(): String = "opphør ved maksdato"
 

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/kafka/UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest.kt
@@ -12,9 +12,9 @@ import no.nav.brukerdialog.utils.KafkaUtils.leggPåTopic
 import no.nav.brukerdialog.utils.KafkaUtils.lesMelding
 import no.nav.brukerdialog.utils.NavHeaders
 import no.nav.brukerdialog.utils.TokenTestUtils.hentToken
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.UngdomsytelseOppgaveUttalelseDTO
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO
 import no.nav.brukerdialog.ytelse.ungdomsytelse.kafka.oppgavebekreftelse.UngdomsytelseOppgavebekreftelseTopologyConfiguration
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.SøknadUtils
 import no.nav.brukerdialog.ytelse.ungdomsytelse.utils.UngdomsytelseOppgavebekreftelseUtils
@@ -113,8 +113,8 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
             oppgave = KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO(
                 oppgaveReferanse = oppgaveReferanse,
                 uttalelse = UngdomsytelseOppgaveUttalelseDTO(
-                    harUttalelse = false,
-                    uttalelseFraDeltaker = null
+                    harUttalelse = true,
+                    uttalelseFraDeltaker = "uttalelse fra bruker"
                 ),
                 sluttdato = LocalDate.parse("2025-12-01"),
                 maksdato = LocalDate.parse("2025-12-01")
@@ -147,8 +147,9 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
             ).value()
 
         val preprosessertSøknadJson = JSONObject(lesMelding).getJSONObject("data").toString()
+        val expectedStr = preprosessertSøknadSomJson(oppgaveReferanse, mottattString)
         JSONAssert.assertEquals(
-            preprosessertSøknadSomJson(oppgaveReferanse, mottattString),
+            expectedStr,
             preprosessertSøknadJson,
             true
         )
@@ -165,8 +166,8 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
             "type": "UNG_OPPHOR_VED_MAKSDATO",
             "oppgaveReferanse": "$oppgaveReferanse",
             "uttalelse": {
-                "harUttalelse": false,
-                "uttalelseFraDeltaker": null
+                "harUttalelse": true,
+                "uttalelseFraDeltaker": "uttalelse fra bruker"
             },
             "sluttdato": "2025-12-01",
             "maksdato": "2025-12-01"
@@ -199,8 +200,8 @@ class UngdomsytelseOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegrati
               "type": "UNG_OPPHOR_VED_MAKSDATO",
               "sluttdato": "2025-12-01",
               "oppgaveReferanse": "$oppgaveReferanse",
-              "uttalelseFraBruker": null,
-              "harUttalelse": false,
+              "uttalelseFraBruker": "uttalelse fra bruker",
+              "harUttalelse": true,
               "dataBruktTilUtledning": null
             },
             "kildesystem": "søknadsdialog"


### PR DESCRIPTION
### Behov / Bakgrunn
uttalelseFraBruker blir ikke journalført etter refaktorering i https://github.com/navikt/k9-format/pull/610. I koden forventes det at Bekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker) muterer Bekreftelsen, men i virkeligheten lager den et nytt objekt. Dermed blir det gamle objektet uten uttalelsetekst journalført og sendt til ung-sak

### Løsning
Fjerner bruken av medUttalelseFraBruker. Gjør også forbedringer i k9-format: 
