### PR TITLE
Mapper bostedsbekreftelse om til KomplettBekreftBostedOppgaveDTO

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/AktivitetspengerOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/AktivitetspengerOppgaveDTO.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Hidden
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.BrukerdialogOppgaveDto
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.bosted.BekreftBostedOppgavetypeDataDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.KontrollerRegisterinntektOppgavetypeDataDto
 import org.hibernate.validator.constraints.UUID
 
@@ -14,12 +15,16 @@ data class AktivitetspengerOppgaveDTO(
 ) {
     fun somKomplettOppgave(oppgaveDTO: BrukerdialogOppgaveDto): KomplettAktivitetspengerOppgaveDTO {
         return when (val oppgavetypeData = oppgaveDTO.oppgavetypeData) {
-            is KontrollerRegisterinntektOppgavetypeDataDto -> KomplettAktivitetspengerOppgaveDTO(
+            is KontrollerRegisterinntektOppgavetypeDataDto -> KomplettKontrollerRegisterinntektOppgaveDTO(
                 oppgaveReferanse = oppgaveReferanse,
                 fraOgMed = oppgavetypeData.fraOgMed,
                 tilOgMed = oppgavetypeData.tilOgMed,
                 registerinntekt = oppgavetypeData.registerinntekt,
                 uttalelse = uttalelse,
+            )
+            is BekreftBostedOppgavetypeDataDto -> KomplettBekreftBostedOppgaveDTO(
+                oppgaveReferanse = oppgaveReferanse,
+                uttalelse = uttalelse
             )
             else -> throw IllegalArgumentException("Ugyldig oppgavetypeData for aktivitetspenger: ${oppgaveDTO.oppgavetypeData}")
         }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettAktivitetspengerOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettAktivitetspengerOppgaveDTO.kt
@@ -1,29 +1,30 @@
 package no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretSluttdatoUngdomsytelseOppgaveDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretStartdatoUngdomsytelseOppgaveDTO
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettUngdomsytelseOppgaveDTO
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse
 import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.BrukerdialogOppgaveDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.RegisterinntektDTO
 import java.time.LocalDate
 import java.util.UUID
 
-data class KomplettAktivitetspengerOppgaveDTO(
-    val oppgaveReferanse: String,
-    val uttalelse: AktivitetspengerOppgaveUttalelseDTO,
-    val fraOgMed: LocalDate,
-    val tilOgMed: LocalDate,
-    val registerinntekt: RegisterinntektDTO,
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = KomplettKontrollerRegisterinntektOppgaveDTO::class, name = Bekreftelse.UNG_AVVIK_REGISTERINNTEKT),
+    JsonSubTypes.Type(value = KomplettBekreftBostedOppgaveDTO::class, name = Bekreftelse.AVP_BOSTED_AVKLARING)
+)
+sealed class KomplettAktivitetspengerOppgaveDTO(
+    open val oppgaveReferanse: String,
+    open val uttalelse: AktivitetspengerOppgaveUttalelseDTO,
 ) {
-    fun somK9Format(): Bekreftelse {
-        val inntektBekreftelse = InntektBekreftelse.builder()
-            .medOppgaveReferanse(UUID.fromString(oppgaveReferanse))
-            .medHarUttalelse(uttalelse.harUttalelse)
-
-        if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
-            inntektBekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
-        }
-
-        return inntektBekreftelse.build()
-    }
-
-    fun dokumentTittelSuffix(): String = "kontroll av lønn"
+    abstract fun somK9Format(): Bekreftelse
+    abstract fun dokumentTittelSuffix(): String
 }

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettAktivitetspengerOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettAktivitetspengerOppgaveDTO.kt
@@ -2,15 +2,7 @@ package no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftels
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretSluttdatoUngdomsytelseOppgaveDTO
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretStartdatoUngdomsytelseOppgaveDTO
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettUngdomsytelseOppgaveDTO
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse
-import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse
-import no.nav.ung.brukerdialog.kontrakt.oppgaver.BrukerdialogOppgaveDto
-import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.RegisterinntektDTO
-import java.time.LocalDate
-import java.util.UUID
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettBekreftBostedOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettBekreftBostedOppgaveDTO.kt
@@ -1,7 +1,7 @@
 package no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse
 
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse
-import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse
+import no.nav.k9.oppgave.bekreftelse.ung.bosatt.BostedAvklaringBekreftelse
 import java.util.*
 
 data class KomplettBekreftBostedOppgaveDTO(
@@ -9,15 +9,16 @@ data class KomplettBekreftBostedOppgaveDTO(
     override val uttalelse: AktivitetspengerOppgaveUttalelseDTO,
 ) : KomplettAktivitetspengerOppgaveDTO(oppgaveReferanse, uttalelse) {
     override fun somK9Format(): Bekreftelse {
-        val bostedsbekreftelse = InntektBekreftelse.builder()
-            .medOppgaveReferanse(UUID.fromString(oppgaveReferanse))
-            .medHarUttalelse(uttalelse.harUttalelse)
 
-        if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
-            bostedsbekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
-        }
+        val uttalelseFraBruker = if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
+            uttalelse.uttalelseFraDeltaker
+        } else null
 
-        return bostedsbekreftelse.build()
+        return BostedAvklaringBekreftelse(
+            UUID.fromString(oppgaveReferanse),
+            uttalelse.harUttalelse,
+            uttalelseFraBruker
+        )
     }
 
     override fun dokumentTittelSuffix(): String = "bekreftelse av bosted"

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettBekreftBostedOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettBekreftBostedOppgaveDTO.kt
@@ -1,0 +1,24 @@
+package no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse
+import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse
+import java.util.*
+
+data class KomplettBekreftBostedOppgaveDTO(
+    override val oppgaveReferanse: String,
+    override val uttalelse: AktivitetspengerOppgaveUttalelseDTO,
+) : KomplettAktivitetspengerOppgaveDTO(oppgaveReferanse, uttalelse) {
+    override fun somK9Format(): Bekreftelse {
+        val bostedsbekreftelse = InntektBekreftelse.builder()
+            .medOppgaveReferanse(UUID.fromString(oppgaveReferanse))
+            .medHarUttalelse(uttalelse.harUttalelse)
+
+        if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
+            bostedsbekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
+        }
+
+        return bostedsbekreftelse.build()
+    }
+
+    override fun dokumentTittelSuffix(): String = "bekreftelse av bosted"
+}

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettKontrollerRegisterinntektOppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/api/domene/oppgavebekreftelse/KomplettKontrollerRegisterinntektOppgaveDTO.kt
@@ -1,0 +1,32 @@
+package no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse
+import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.RegisterinntektDTO
+import java.time.LocalDate
+import java.util.*
+
+
+data class KomplettKontrollerRegisterinntektOppgaveDTO(
+    override val oppgaveReferanse: String,
+    override val uttalelse: AktivitetspengerOppgaveUttalelseDTO,
+    val fraOgMed: LocalDate,
+    val tilOgMed: LocalDate,
+    val registerinntekt: RegisterinntektDTO,
+) : KomplettAktivitetspengerOppgaveDTO(oppgaveReferanse, uttalelse) {
+
+    override fun somK9Format(): Bekreftelse {
+        val inntektBekreftelse = InntektBekreftelse.builder()
+            .medOppgaveReferanse(UUID.fromString(oppgaveReferanse))
+            .medHarUttalelse(uttalelse.harUttalelse)
+
+        if (!uttalelse.uttalelseFraDeltaker.isNullOrBlank()) {
+            inntektBekreftelse.medUttalelseFraBruker(uttalelse.uttalelseFraDeltaker)
+        }
+
+        return inntektBekreftelse.build()
+    }
+
+    override fun dokumentTittelSuffix(): String = "kontroll av lønn"
+}
+

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/pdf/AktivitetspengerOppgavebekreftelsePdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/pdf/AktivitetspengerOppgavebekreftelsePdfData.kt
@@ -10,7 +10,11 @@ import no.nav.brukerdialog.utils.DateUtils.somNorskMåned
 import no.nav.brukerdialog.utils.NumberUtils.formaterSomValuta
 import no.nav.brukerdialog.utils.StringUtils.språkTilTekst
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.AktivitetspengerOppgaveUttalelseDTO
+import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettAktivitetspengerOppgaveDTO
+import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettBekreftBostedOppgaveDTO
+import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettKontrollerRegisterinntektOppgaveDTO
 import no.nav.brukerdialog.ytelse.aktivitetspenger.kafka.oppgavebekreftelse.domene.AktivitetspengerOppgavebekreftelseMottatt
+import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretStartdatoUngdomsytelseOppgaveDTO
 import no.nav.k9.søknad.felles.type.Språk
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.RegisterinntektDTO
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.YtelseType
@@ -27,17 +31,7 @@ class AktivitetspengerOppgavebekreftelsePdfData(
         val k9Format = oppgavebekreftelseMottatt.k9Format
         return mapOf(
             "tittel" to ytelse().utledTittel(språk()) + oppgavebekreftelseMottatt.oppgave.dokumentTittelSuffix(),
-            "oppgave" to mapOf(
-                "oppgaveReferanse" to oppgavebekreftelseMottatt.oppgave.oppgaveReferanse,
-                "uttalelse" to oppgavebekreftelseMottatt.oppgave.uttalelse.somMap(),
-                "kontrollerRegisterInntektOppgave" to mapOf(
-                    "fraOgMed" to DATE_FORMATTER.format(oppgavebekreftelseMottatt.oppgave.fraOgMed),
-                    "månedÅr" to "${oppgavebekreftelseMottatt.oppgave.fraOgMed.month.somNorskMåned()} ${oppgavebekreftelseMottatt.oppgave.fraOgMed.year}",
-                    "tilOgMed" to DATE_FORMATTER.format(oppgavebekreftelseMottatt.oppgave.tilOgMed),
-                    "registerinntekt" to oppgavebekreftelseMottatt.oppgave.registerinntekt.somMap(),
-                    "spørsmål" to "Har du tilbakemelding på lønnen?",
-                ),
-            ),
+            "oppgave" to oppgavebekreftelseMottatt.oppgave.somMap(),
             "søknadMottattDag" to oppgavebekreftelseMottatt.mottatt.withZoneSameInstant(OSLO_ZONE_ID).somNorskDag(),
             "søknadMottatt" to DATE_TIME_FORMATTER.format(oppgavebekreftelseMottatt.mottatt),
             "søker" to oppgavebekreftelseMottatt.søker.somMap(),
@@ -46,6 +40,19 @@ class AktivitetspengerOppgavebekreftelsePdfData(
             ),
         )
     }
+
+    private fun KomplettAktivitetspengerOppgaveDTO.somMap() = mapOf(
+        "oppgaveReferanse" to oppgaveReferanse,
+        "uttalelse" to uttalelse.somMap(),
+        "kontrollerRegisterInntektOppgave" to if (this is KomplettKontrollerRegisterinntektOppgaveDTO) mapOf(
+            "fraOgMed" to DATE_FORMATTER.format(fraOgMed),
+            "månedÅr" to "${fraOgMed.month.somNorskMåned()} ${fraOgMed.year}",
+            "tilOgMed" to DATE_FORMATTER.format(tilOgMed),
+            "registerinntekt" to registerinntekt.somMap(),
+            "spørsmål" to "Har du tilbakemelding på lønnen?"
+        ) else null,
+    )
+
 
     private fun RegisterinntektDTO.somMap() = mapOf(
         "arbeidOgFrilansInntekter" to this.arbeidOgFrilansInntekter.map {

--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/pdf/AktivitetspengerOppgavebekreftelsePdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/pdf/AktivitetspengerOppgavebekreftelsePdfData.kt
@@ -14,7 +14,6 @@ import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettBekreftBostedOppgaveDTO
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettKontrollerRegisterinntektOppgaveDTO
 import no.nav.brukerdialog.ytelse.aktivitetspenger.kafka.oppgavebekreftelse.domene.AktivitetspengerOppgavebekreftelseMottatt
-import no.nav.brukerdialog.ytelse.ungdomsytelse.api.domene.oppgavebekreftelse.KomplettEndretStartdatoUngdomsytelseOppgaveDTO
 import no.nav.k9.søknad.felles.type.Språk
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.RegisterinntektDTO
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.YtelseType
@@ -44,6 +43,7 @@ class AktivitetspengerOppgavebekreftelsePdfData(
     private fun KomplettAktivitetspengerOppgaveDTO.somMap() = mapOf(
         "oppgaveReferanse" to oppgaveReferanse,
         "uttalelse" to uttalelse.somMap(),
+        "bekreftBosted" to if (this is KomplettBekreftBostedOppgaveDTO) true else null,
         "kontrollerRegisterInntektOppgave" to if (this is KomplettKontrollerRegisterinntektOppgaveDTO) mapOf(
             "fraOgMed" to DATE_FORMATTER.format(fraOgMed),
             "månedÅr" to "${fraOgMed.month.somNorskMåned()} ${fraOgMed.year}",

--- a/src/main/resources/handlebars/aktivitetspenger-oppgave-bekreftelse.hbs
+++ b/src/main/resources/handlebars/aktivitetspenger-oppgave-bekreftelse.hbs
@@ -11,6 +11,7 @@
     <bookmarks>
         <bookmark name="Søker" href="#søker"/>
         <bookmark name="Kontrollere inntekt fra register" href="#kontrollerRegisterInntektOppgave"/>
+        <bookmark name="Tilbakemelding på bosted" href="#bekreftBosted"/>
     </bookmarks>
     {{#block 'style-common' }}
     {{/block}}
@@ -73,6 +74,18 @@
                     spørsmålstekstUttalelse=oppgave.kontrollerRegisterInntektOppgave.spørsmål
             }}
 
+        </section>
+    {{/if}}
+
+    {{#if oppgave.bekreftBosted}}
+        <section id="bekreftBosted">
+            <h2>Tilbakemelding på bosted</h2>
+
+            <br/>
+            {{> partial/ung/uttalelsePartial
+                    uttalelse=oppgave.uttalelse
+                    spørsmålstekstUttalelse=oppgave.opphørVedMaksdatoOppgave.spørsmål
+            }}
         </section>
     {{/if}}
 </div>

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengerOppgavebekreftelseInnsendingKonsumentTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/kafka/AktivitetspengerOppgavebekreftelseInnsendingKonsumentTest.kt
@@ -13,6 +13,7 @@ import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse
 import no.nav.brukerdialog.ytelse.aktivitetspenger.kafka.oppgavebekreftelse.AktivitetspengerOppgavebekreftelseTopologyConfiguration
 import no.nav.brukerdialog.ytelse.aktivitetspenger.utils.AktivitetspengerOppgavebekreftelseUtils
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveType
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.bosted.BekreftBostedOppgavetypeDataDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.kontrollerregisterinntekt.KontrollerRegisterinntektOppgavetypeDataDto
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -52,6 +53,70 @@ class AktivitetspengerOppgavebekreftelseInnsendingKonsumentTest : AbstractIntegr
             oppgave = AktivitetspengerOppgaveDTO(
                 oppgaveReferanse = oppgaveReferanse.toString(),
                 uttalelse = AktivitetspengerOppgaveUttalelseDTO(harUttalelse = false),
+            )
+        )
+
+        val token = mockOAuth2Server.hentToken()
+        mockMvc.post("/aktivitetspenger/oppgavebekreftelse/innsending") {
+            headers {
+                set(NavHeaders.BRUKERDIALOG_GIT_SHA, UUID.randomUUID().toString())
+                setBearerAuth(token.serialize())
+            }
+            contentType = MediaType.APPLICATION_JSON
+            accept = MediaType.APPLICATION_JSON
+            content = JacksonConfiguration.configureObjectMapper().writeValueAsString(oppgavebekreftelse)
+        }.andExpect {
+            status {
+                isAccepted()
+                header { exists(NavHeaders.X_CORRELATION_ID) }
+            }
+        }
+
+        coVerify(exactly = 1, timeout = 60 * 1000) {
+            dokumentService.slettDokumenter(any(), any())
+        }
+
+        k9DittnavVarselConsumer.lesMelding(
+            key = oppgaveReferanse.toString(),
+            topic = DittnavVarselTopologyConfiguration.K9_DITTNAV_VARSEL_TOPIC
+        ).value().assertDittnavVarsel(
+            K9Beskjed(
+                metadata = no.nav.brukerdialog.utils.SøknadUtils.metadata,
+                grupperingsId = oppgaveReferanse.toString(),
+                tekst = "Bekreftelse om aktivitetspengeropplysninger er mottatt",
+                link = null,
+                dagerSynlig = 7,
+                søkerFødselsnummer = søker.fødselsnummer,
+                eventId = "testes ikke",
+                ytelse = "AKTIVITETSPENGER",
+            )
+        )
+    }
+
+    @Test
+    fun `forvent at bekreftelse av bosted konsumeres riktig og dokumenter blir slettet`() {
+        val søker = mockSøker()
+        mockBarn()
+        mockLagreDokument()
+        mockJournalføring()
+        mockHentingAvOppgave(
+            oppgavetype = OppgaveType.BEKREFT_BOSTED,
+            oppgavetypeData = BekreftBostedOppgavetypeDataDto(
+                LocalDate.parse("2025-06-01"),
+                LocalDate.parse("2025-06-30"),
+                false,
+            )
+        )
+        mockMarkerOppgaveSomLøst()
+
+        val oppgaveReferanse = UUID.randomUUID()
+        val oppgavebekreftelse = AktivitetspengerOppgavebekreftelseUtils.defaultOppgavebekreftelse.copy(
+            oppgave = AktivitetspengerOppgaveDTO(
+                oppgaveReferanse = oppgaveReferanse.toString(),
+                uttalelse = AktivitetspengerOppgaveUttalelseDTO(
+                    harUttalelse = true,
+                    uttalelseFraDeltaker = "Jeg er ikke lenger bosatt i Trondheim, uttalelsen skal ikke gå tapt",
+                ),
             )
         )
 

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/pdf/AktivitetspengerOppgavebekreftelsePdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/pdf/AktivitetspengerOppgavebekreftelsePdfGeneratorTest.kt
@@ -61,6 +61,31 @@ class AktivitetspengerOppgavebekreftelsePdfGeneratorTest {
                 ).pdfData()
             )
             if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+            id = "3-bekrefter-bosted-uten-uttalelse"
+            pdf = generator.genererPDF(
+                AktivitetspengerOppgavebekreftelseUtils.oppgavebekreftelseMottatt(
+                    oppgave = AktivitetspengerOppgavebekreftelseUtils.defaultBekreftBostedOppgave.copy(
+                        oppgaveReferanse = UUID.randomUUID().toString(),
+                        uttalelse = AktivitetspengerOppgaveUttalelseDTO(harUttalelse = false),
+                    )
+                ).pdfData()
+            )
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
+
+            id = "4-bekrefter-bosted-med-uttalelse"
+            pdf = generator.genererPDF(
+                AktivitetspengerOppgavebekreftelseUtils.oppgavebekreftelseMottatt(
+                    oppgave = AktivitetspengerOppgavebekreftelseUtils.defaultBekreftBostedOppgave.copy(
+                        oppgaveReferanse = UUID.randomUUID().toString(),
+                        uttalelse = AktivitetspengerOppgaveUttalelseDTO(
+                            harUttalelse = true,
+                            uttalelseFraDeltaker = "Jeg er ikke lenger bosatt i Trondheim, og ønsker å gi en tilbakemelding på dette.",
+                        ),
+                    )
+                ).pdfData()
+            )
+            if (writeBytes) File(pdfPath(soknadId = id, prefix = PDF_PREFIX)).writeBytes(pdf)
         }
     }
 }

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengerOppgavebekreftelseUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengerOppgavebekreftelseUtils.kt
@@ -4,6 +4,7 @@ import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.AktivitetspengerOppgavebekreftelse
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.AktivitetspengerOppgaveUttalelseDTO
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettAktivitetspengerOppgaveDTO
+import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettBekreftBostedOppgaveDTO
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettKontrollerRegisterinntektOppgaveDTO
 import no.nav.brukerdialog.ytelse.aktivitetspenger.kafka.oppgavebekreftelse.domene.AktivitetspengerOppgavebekreftelseMottatt
 import no.nav.brukerdialog.ytelse.fellesdomene.Søker
@@ -38,6 +39,11 @@ object AktivitetspengerOppgavebekreftelseUtils {
         fraOgMed = LocalDate.parse("2025-06-01"),
         tilOgMed = LocalDate.parse("2025-06-30"),
         registerinntekt = defaultRegisterinntekt,
+    )
+
+    val defaultBekreftBostedOppgave = KomplettBekreftBostedOppgaveDTO(
+        oppgaveReferanse = UUID.randomUUID().toString(),
+        uttalelse = AktivitetspengerOppgaveUttalelseDTO(harUttalelse = false),
     )
 
     val defaultOppgavebekreftelse = AktivitetspengerOppgavebekreftelse(

--- a/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengerOppgavebekreftelseUtils.kt
+++ b/src/test/kotlin/no/nav/brukerdialog/ytelse/aktivitetspenger/utils/AktivitetspengerOppgavebekreftelseUtils.kt
@@ -4,6 +4,7 @@ import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.AktivitetspengerOppgavebekreftelse
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.AktivitetspengerOppgaveUttalelseDTO
 import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettAktivitetspengerOppgaveDTO
+import no.nav.brukerdialog.ytelse.aktivitetspenger.api.domene.oppgavebekreftelse.KomplettKontrollerRegisterinntektOppgaveDTO
 import no.nav.brukerdialog.ytelse.aktivitetspenger.kafka.oppgavebekreftelse.domene.AktivitetspengerOppgavebekreftelseMottatt
 import no.nav.brukerdialog.ytelse.fellesdomene.Søker
 import no.nav.k9.oppgave.OppgaveBekreftelse
@@ -31,7 +32,7 @@ object AktivitetspengerOppgavebekreftelseUtils {
         ),
     )
 
-    val defaultKomplettOppgave = KomplettAktivitetspengerOppgaveDTO(
+    val defaultKomplettOppgave = KomplettKontrollerRegisterinntektOppgaveDTO(
         oppgaveReferanse = UUID.randomUUID().toString(),
         uttalelse = AktivitetspengerOppgaveUttalelseDTO(harUttalelse = false),
         fraOgMed = LocalDate.parse("2025-06-01"),


### PR DESCRIPTION
### Behov / Bakgrunn
Bruker skal kunne bekrefte oppgave om bosted i forbindelse med revurdering/opphør av aktivitetspenger.
https://nav-it.slack.com/archives/C07KQ87T3GE/p1782824220151359

### Løsning
Mapper ny BekreftBostedOppgavetypeDataDto om til KomplettBekreftBostedOppgaveDTO.
Legger til støtte for flere typer, med samme mønster som ungdomsprogramytelsen har.

