### PR TITLE
feat(ungdomsytelse): oppdaterer PDF for oppgavebekreftelse for opphør ved maksdato.

### DIFF
--- a/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
+++ b/src/main/kotlin/no/nav/brukerdialog/ytelse/ungdomsytelse/pdf/UngdomsytelseOppgavebekreftelsePdfData.kt
@@ -78,9 +78,8 @@ class UngdomsytelseOppgavebekreftelsePdfData(private val oppgavebekreftelseMotta
 
         "opphørVedMaksdatoOppgave" to when (this) {
             is KomplettOpphørVedMaksdatoUngdomsytelseOppgaveDTO -> mapOf(
-                "sluttdato" to DATE_FORMATTER.format(sluttdato),
                 "maksdato" to DATE_FORMATTER.format(maksdato),
-                "spørsmål" to "Mener du at sluttdatoen eller maksdatoen er feil?"
+                "spørsmål" to "Mener du at maksdatoen er feil?"
             )
 
             else -> null

--- a/src/main/resources/handlebars/ungdomsytelse-oppgave-bekreftelse.hbs
+++ b/src/main/resources/handlebars/ungdomsytelse-oppgave-bekreftelse.hbs
@@ -123,9 +123,7 @@
     {{#if oppgave.opphørVedMaksdatoOppgave}}
         <section id="ytelsenStopperVedMaksdato">
             <h2>Ungdomsytelsen stopper ved maksdato</h2>
-
-            <p>Siste dag du får ungdomsytelse er {{oppgave.opphørVedMaksdatoOppgave.sluttdato}}.</p>
-            <p>Maksdatoen din er {{oppgave.opphørVedMaksdatoOppgave.maksdato}}.</p>
+            <p>Din siste dag med ungdomsprogramytelsen er {{oppgave.opphørVedMaksdatoOppgave.maksdato}}.</p>
 
             <br/>
             {{> partial/ung/uttalelsePartial


### PR DESCRIPTION
### Behov / Bakgrunn

Teksten i PDF-en for bekreftelse av oppgave av opphør ved maksdato er ikke som forventet.


### Løsning
- Gjør teksten tydeligere og fjerner info om sluttdato da den ikke trengs.


